### PR TITLE
add endpoint option for S3 compatible providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ the bucket.
 
 * `region_name`: *Optional. Default `us-east-1`.* The region the bucket is in.
 
+* `endpoint`: *Optional. Custom endpoint for using S3 compatible provider.
 
 ## Behavior
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the bucket.
 
 * `region_name`: *Optional. Default `us-east-1`.* The region the bucket is in.
 
-* `endpoint`: *Optional. Custom endpoint for using S3 compatible provider.
+* `endpoint`: *Optional.* Custom endpoint for using S3 compatible provider.
 
 ## Behavior
 

--- a/check/main.go
+++ b/check/main.go
@@ -34,6 +34,10 @@ func main() {
 		fatal("resolving region name", errors.New(fmt.Sprintf("No such region '%s'", regionName)))
 	}
 
+	if len(request.Source.Endpoint) != 0 {
+		region = aws.Region{S3Endpoint: fmt.Sprintf("https://%s", request.Source.Endpoint)}
+	}
+
 	client := s3.New(auth, region)
 	bucket := client.Bucket(request.Source.Bucket)
 

--- a/in/main.go
+++ b/in/main.go
@@ -49,6 +49,10 @@ func main() {
 		fatal("resolving region name", errors.New(fmt.Sprintf("No such region '%s'", regionName)))
 	}
 
+	if len(request.Source.Endpoint) != 0 {
+		region = aws.Region{S3Endpoint: fmt.Sprintf("https://%s", request.Source.Endpoint)}
+	}
+
 	client := s3.New(auth, region)
 	bucket := client.Bucket(request.Source.Bucket)
 

--- a/models/models.go
+++ b/models/models.go
@@ -49,6 +49,7 @@ type Source struct {
 	SecretAccessKey string `json:"secret_access_key"`
 	RegionName      string `json:"region_name"`
 	InitialVersion  string `json:"initial_version"`
+	Endpoint        string `json:"endpoint"`
 }
 
 type Metadata []MetadataField

--- a/out/main.go
+++ b/out/main.go
@@ -53,6 +53,11 @@ func main() {
 	if !ok {
 		fatal("resolving region name", errors.New(fmt.Sprintf("No such region '%s'", regionName)))
 	}
+
+	if len(request.Source.Endpoint) != 0 {
+		region = aws.Region{S3Endpoint: fmt.Sprintf("https://%s", request.Source.Endpoint)}
+	}
+
 	client := s3.New(auth, region)
 	bucket := client.Bucket(request.Source.Bucket)
 
@@ -60,7 +65,7 @@ func main() {
 		Number: v.String(),
 	}
 
-	err = bucket.Put(request.Source.Key, []byte(outVersion.Number), "text/plain", "")
+	err = bucket.Put(request.Source.Key, []byte(outVersion.Number), "text/plain", s3.BucketOwnerFull)
 	if err != nil {
 		fatal("saving to bucket", err)
 	}

--- a/out/main.go
+++ b/out/main.go
@@ -65,7 +65,7 @@ func main() {
 		Number: v.String(),
 	}
 
-	err = bucket.Put(request.Source.Key, []byte(outVersion.Number), "text/plain", s3.BucketOwnerFull)
+	err = bucket.Put(request.Source.Key, []byte(outVersion.Number), "text/plain", s3.Private)
 	if err != nil {
 		fatal("saving to bucket", err)
 	}


### PR DESCRIPTION
Adds an option to specify a custom S3 compatible endpoint.
Default behaviour for AWS stays the same.

Signed-off-by: Fabio Berchtold <fabio.berchtold@swisscom.com>