### PR TITLE
Host key verification failed.

### DIFF
--- a/driver/git.go
+++ b/driver/git.go
@@ -165,7 +165,7 @@ func (driver *GitDriver) setUpKey() error {
 		}
 	}
 
-	return os.Setenv("GIT_SSH_COMMAND", "ssh -i "+privateKeyPath)
+	return os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no -i "+privateKeyPath)
 }
 
 func (driver *GitDriver) readVersion() (semver.Version, bool, error) {


### PR DESCRIPTION
To help defeat this error condition: 

```
Cloning into '/tmp/semver-git-repo'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
error bumping version: exit status 128
```