### PR TITLE
Add support for use of AWS instance profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ The `s3` driver works by modifying a file a file in a bucket.
 * `key`: *Required.* The key to use for the object in the bucket tracking
 the version.
 
-* `access_key_id`: *Required.* The AWS access key to use when accessing the
-bucket.
+* `access_key_id`: *Optional.* The AWS access key to use when accessing the
+bucket. If empty, the resource will try to retrieve credentials from environment
+or [AWS instance profile](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html)
 
-* `secret_access_key`: *Required.* The AWS secret key to use when accessing
-the bucket.
+* `secret_access_key`: *Optional.* The AWS secret key to use when accessing
+the bucket. If empty, the resource will try to retrieve credentials from environment
+or [AWS instance profile](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html)
 
 * `region_name`: *Optional. Default `us-east-1`.* The region the bucket is in.
 

--- a/check/check_suite_test.go
+++ b/check/check_suite_test.go
@@ -11,6 +11,7 @@ import (
 
 var checkPath string
 
+var useInstanceProfile = os.Getenv("SEMVER_TESTING_USE_INSTANCE_PROFILE")
 var accessKeyID = os.Getenv("SEMVER_TESTING_ACCESS_KEY_ID")
 var secretAccessKey = os.Getenv("SEMVER_TESTING_SECRET_ACCESS_KEY")
 var bucketName = os.Getenv("SEMVER_TESTING_BUCKET")
@@ -19,8 +20,10 @@ var regionName = os.Getenv("SEMVER_TESTING_REGION")
 var _ = BeforeSuite(func() {
 	var err error
 
-	Ω(accessKeyID).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_ACCESS_KEY_ID")
-	Ω(secretAccessKey).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_SECRET_ACCESS_KEY")
+	if useInstanceProfile == "" {
+		Ω(accessKeyID).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_ACCESS_KEY_ID or SEMVER_TESTING_USE_INSTANCE_PROFILE=true")
+		Ω(secretAccessKey).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_SECRET_ACCESS_KEY or SEMVER_TESTING_USE_INSTANCE_PROFILE=true")
+	}
 	Ω(bucketName).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_BUCKET")
 	Ω(regionName).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_REGION")
 

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -52,10 +52,8 @@ var _ = Describe("Check", func() {
 
 			key = guid.String()
 
-			auth := aws.Auth{
-				AccessKey: accessKeyID,
-				SecretKey: secretAccessKey,
-			}
+			auth, err := aws.GetAuth(accessKeyID, secretAccessKey)
+			Ω(err).ShouldNot(HaveOccurred())
 
 			region, ok := aws.Regions[regionName]
 			Ω(ok).Should(BeTrue())

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -32,9 +32,9 @@ func FromSource(source models.Source) (Driver, error) {
 
 	switch source.Driver {
 	case models.DriverUnspecified, models.DriverS3:
-		auth := aws.Auth{
-			AccessKey: source.AccessKeyID,
-			SecretKey: source.SecretAccessKey,
+		auth, err := aws.GetAuth(source.AccessKeyID, source.SecretAccessKey)
+		if err != nil {
+			return nil, err
 		}
 
 		regionName := source.RegionName

--- a/in/in_suite_test.go
+++ b/in/in_suite_test.go
@@ -11,6 +11,7 @@ import (
 
 var inPath string
 
+var useInstanceProfile = os.Getenv("SEMVER_TESTING_USE_INSTANCE_PROFILE")
 var accessKeyID = os.Getenv("SEMVER_TESTING_ACCESS_KEY_ID")
 var secretAccessKey = os.Getenv("SEMVER_TESTING_SECRET_ACCESS_KEY")
 var bucketName = os.Getenv("SEMVER_TESTING_BUCKET")
@@ -19,8 +20,10 @@ var regionName = os.Getenv("SEMVER_TESTING_REGION")
 var _ = BeforeSuite(func() {
 	var err error
 
-	Ω(accessKeyID).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_ACCESS_KEY_ID")
-	Ω(secretAccessKey).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_SECRET_ACCESS_KEY")
+	if useInstanceProfile == "" {
+		Ω(accessKeyID).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_ACCESS_KEY_ID or SEMVER_TESTING_USE_INSTANCE_PROFILE=true")
+		Ω(secretAccessKey).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_SECRET_ACCESS_KEY or SEMVER_TESTING_USE_INSTANCE_PROFILE=true")
+	}
 	Ω(bucketName).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_BUCKET")
 	Ω(regionName).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_REGION")
 

--- a/in/in_test.go
+++ b/in/in_test.go
@@ -53,10 +53,8 @@ var _ = Describe("In", func() {
 
 			key = guid.String()
 
-			auth := aws.Auth{
-				AccessKey: accessKeyID,
-				SecretKey: secretAccessKey,
-			}
+			auth, err := aws.GetAuth(accessKeyID, secretAccessKey)
+			Ω(err).ShouldNot(HaveOccurred())
 
 			region, ok := aws.Regions[regionName]
 			Ω(ok).Should(BeTrue())

--- a/out/out_suite_test.go
+++ b/out/out_suite_test.go
@@ -11,6 +11,7 @@ import (
 
 var outPath string
 
+var useInstanceProfile = os.Getenv("SEMVER_TESTING_USE_INSTANCE_PROFILE")
 var accessKeyID = os.Getenv("SEMVER_TESTING_ACCESS_KEY_ID")
 var secretAccessKey = os.Getenv("SEMVER_TESTING_SECRET_ACCESS_KEY")
 var bucketName = os.Getenv("SEMVER_TESTING_BUCKET")
@@ -19,8 +20,10 @@ var regionName = os.Getenv("SEMVER_TESTING_REGION")
 var _ = BeforeSuite(func() {
 	var err error
 
-	Ω(accessKeyID).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_ACCESS_KEY_ID")
-	Ω(secretAccessKey).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_SECRET_ACCESS_KEY")
+	if useInstanceProfile == "" {
+		Ω(accessKeyID).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_ACCESS_KEY_ID or SEMVER_TESTING_USE_INSTANCE_PROFILE=true")
+		Ω(secretAccessKey).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_SECRET_ACCESS_KEY or SEMVER_TESTING_USE_INSTANCE_PROFILE=true")
+	}
 	Ω(bucketName).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_BUCKET")
 	Ω(regionName).ShouldNot(BeEmpty(), "must specify $SEMVER_TESTING_REGION")
 

--- a/out/out_test.go
+++ b/out/out_test.go
@@ -50,10 +50,8 @@ var _ = Describe("Out", func() {
 
 			key = guid.String()
 
-			auth := aws.Auth{
-				AccessKey: accessKeyID,
-				SecretKey: secretAccessKey,
-			}
+			auth, err := aws.GetAuth(accessKeyID, secretAccessKey)
+			Ω(err).ShouldNot(HaveOccurred())
 
 			region, ok := aws.Regions[regionName]
 			Ω(ok).Should(BeTrue())


### PR DESCRIPTION
# What 

Implement the possibility of use [IAM profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) instead of specify the static AWS credentials.

# Context

This PR uses the logic already implement in https://github.com/mitchellh/goamz/blob/master/aws/aws.go#L313 aws.GetAuth, and it simply changes the creation of the Auth struct with that function. If the credentials are empty, the library will automatically try to retrieve the credentials from environment or the instance profile.

# Testing

Get the code:

```
go get -d github.com/concourse/semver-resource
cd $GOPATH/src/github.com/concourse/semver-resource
git remote add alphagov https://github.com/alphagov/paas-semver-resource
git fetch alphagov
git checkout use_instance_profile
go get ./...
```

The tests are changed to allow test it in a server with a IAM role. For that create an AWS instance with the desired policies to access the bucket and run the tests specifying `SEMVER_TESTING_USE_INSTANCE_PROFILE=1`:

```
SEMVER_TESTING_USE_INSTANCE_PROFILE=1 \
SEMVER_TESTING_ACCESS_KEY_ID= \
SEMVER_TESTING_SECRET_ACCESS_KEY= \
SEMVER_TESTING_BUCKET=bucketname \
SEMVER_TESTING_REGION=eu-west-1 \
go test ./...
``` 

And locally with static credentials as usual:

```
SEMVER_TESTING_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
SEMVER_TESTING_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
SEMVER_TESTING_BUCKET=bucketname \
SEMVER_TESTING_REGION=eu-west-1 \
go test ./...
```
