### PR TITLE
Adding git identity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The `git` driver works by modifying a file in a repository with every bump. The
 * `private_key`: *Optional.* The SSH private key to use when pulling
   from/pushing to the repository.
 
-* `git_user`: *Optional.* The git identiy to use when pushing to the
+* `git_user`: *Optional.* The git identity to use when pushing to the
   repository support RFC 5322 address of the form "Gogh Fir <gf@example.com>" or "foo@example.com".
 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ The `git` driver works by modifying a file in a repository with every bump. The
 * `file`: *Required.* The name of the file in the repository.
 
 * `private_key`: *Optional.* The SSH private key to use when pulling
-  from/pushing to to the repository.
+  from/pushing to the repository.
+
+* `git_user`: *Optional.* The git identiy to use when pushing to the
+  repository support RFC 5322 address of the form "Gogh Fir <gf@example.com>" or "foo@example.com".
 
 
 ### `s3` Driver

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -71,6 +71,7 @@ func FromSource(source models.Source) (Driver, error) {
 			Branch:     source.Branch,
 			PrivateKey: source.PrivateKey,
 			File:       source.File,
+			GitUser:    source.GitUser,
 		}, nil
 
 	case models.DriverSwift:

--- a/models/models.go
+++ b/models/models.go
@@ -61,6 +61,7 @@ type Source struct {
 	Branch     string `json:"branch"`
 	PrivateKey string `json:"private_key"`
 	File       string `json:"file"`
+	GitUser    string `json:"git_user"`
 
 	OpenStack OpenStackOptions `json:"openstack"`
 }


### PR DESCRIPTION
It can be nice to give the mail and username of the git user which put to the repository.


This PR add this support with the field : 

`git_user`: *Optional.*  The git identity to use when pushing to the repository support RFC 5322 address of the form "Gogh Fir <gf@example.com>" or "foo@example.com".

