### PR TITLE
Add disableSSL for s3 compatible providers without SSL endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ the bucket.
 
 * `endpoint`: *Optional.* Custom endpoint for using S3 compatible provider.
 
-* `disableSSL`: *Optional.* Disable SSL for the endpoint, useful for S3 compatible providers without SSL.
-
+* `disable_ssl`: *Optional.* Disable SSL for the endpoint, useful for S3 compatible providers without SSL.
 
 ### `swift` Driver
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ The `git` driver works by modifying a file in a repository with every bump. The
 * `file`: *Required.* The name of the file in the repository.
 
 * `private_key`: *Optional.* The SSH private key to use when pulling from/pushing to to the repository.
-  
+
 * `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.
    This is needed when only HTTP/HTTPS protocol for git is available (which does not support private key auth)
    and auth is required.
- 
+
 * `password`: *Optional.* Password for HTTP(S) auth when pulling/pushing.
 
 * `git_user`: *Optional.* The git identity to use when pushing to the
@@ -56,6 +56,8 @@ the bucket.
 * `region_name`: *Optional. Default `us-east-1`.* The region the bucket is in.
 
 * `endpoint`: *Optional.* Custom endpoint for using S3 compatible provider.
+
+* `disableSSL`: *Optional.* Disable SSL for the endpoint, useful for S3 compatible providers without SSL.
 
 
 ### `swift` Driver

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -53,6 +53,7 @@ func FromSource(source models.Source) (Driver, error) {
 			Credentials:      creds,
 			S3ForcePathStyle: aws.Bool(true),
 			MaxRetries:       aws.Int(maxRetries),
+			DisableSSL:       aws.Bool(source.DisableSSL),
 		}
 
 		if len(source.Endpoint) != 0 {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -57,8 +57,7 @@ func FromSource(source models.Source) (Driver, error) {
 		}
 
 		if len(source.Endpoint) != 0 {
-			endpoint := fmt.Sprintf("%s", source.Endpoint)
-			awsConfig.Endpoint = &endpoint
+			awsConfig.Endpoint = aws.String(source.Endpoint)
 		}
 
 		svc := s3.New(session.New(awsConfig))

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -57,7 +57,7 @@ func FromSource(source models.Source) (Driver, error) {
 		}
 
 		if len(source.Endpoint) != 0 {
-			endpoint := fmt.Sprintf("https://%s", source.Endpoint)
+			endpoint := fmt.Sprintf("%s", source.Endpoint)
 			awsConfig.Endpoint = &endpoint
 		}
 

--- a/models/models.go
+++ b/models/models.go
@@ -56,6 +56,7 @@ type Source struct {
 	SecretAccessKey string `json:"secret_access_key"`
 	RegionName      string `json:"region_name"`
 	Endpoint        string `json:"endpoint"`
+	DisableSSL      bool   `json:"disableSSL"`
 
 	URI        string `json:"uri"`
 	Branch     string `json:"branch"`

--- a/models/models.go
+++ b/models/models.go
@@ -56,7 +56,7 @@ type Source struct {
 	SecretAccessKey string `json:"secret_access_key"`
 	RegionName      string `json:"region_name"`
 	Endpoint        string `json:"endpoint"`
-	DisableSSL      bool   `json:"disableSSL"`
+	DisableSSL      bool   `json:"disable_ssl"`
 
 	URI        string `json:"uri"`
 	Branch     string `json:"branch"`


### PR DESCRIPTION
Minio doesn't provide a HTTPS endpoint. This is also not required when running everything on-site. Therefor disabling SSL (already provided by the AWS sdk) is an easy solution.