### PR TITLE
Add support for using the AWS default credentials chain in the resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ the bucket.
 
 * `disable_ssl`: *Optional.* Disable SSL for the endpoint, useful for S3 compatible providers without SSL.
 
+* `default_credentials`: *Optional. Default `false`.* This option only matters if neither `access_key_id` nor `secret_access_key` are provided. If set to `true`, then the resource uses the default credentials chain. Otherwise, it uses anonymous credentials. 
+
 ### `swift` Driver
 
 The `swift` driver works by modifying a file in a container.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -36,6 +36,7 @@ func FromSource(source models.Source) (Driver, error) {
 	switch source.Driver {
 	case models.DriverUnspecified, models.DriverS3:
 		var creds *credentials.Credentials
+		var awsConfig *aws.Config
 
 		if source.AccessKeyID == "" && source.SecretAccessKey == "" {
 			creds = credentials.AnonymousCredentials
@@ -48,12 +49,15 @@ func FromSource(source models.Source) (Driver, error) {
 			regionName = "us-east-1"
 		}
 
-		awsConfig := &aws.Config{
+		awsConfig = &aws.Config{
 			Region:           aws.String(regionName),
-			Credentials:      creds,
 			S3ForcePathStyle: aws.Bool(true),
 			MaxRetries:       aws.Int(maxRetries),
 			DisableSSL:       aws.Bool(source.DisableSSL),
+		}
+
+		if !(source.DefaultCredentials) {
+			awsConfig = awsConfig.WithCredentials(creds)
 		}
 
 		if len(source.Endpoint) != 0 {

--- a/models/models.go
+++ b/models/models.go
@@ -50,13 +50,14 @@ type Source struct {
 
 	InitialVersion string `json:"initial_version"`
 
-	Bucket          string `json:"bucket"`
-	Key             string `json:"key"`
-	AccessKeyID     string `json:"access_key_id"`
-	SecretAccessKey string `json:"secret_access_key"`
-	RegionName      string `json:"region_name"`
-	Endpoint        string `json:"endpoint"`
-	DisableSSL      bool   `json:"disable_ssl"`
+	Bucket             string `json:"bucket"`
+	Key                string `json:"key"`
+	AccessKeyID        string `json:"access_key_id"`
+	SecretAccessKey    string `json:"secret_access_key"`
+	RegionName         string `json:"region_name"`
+	Endpoint           string `json:"endpoint"`
+	DisableSSL         bool   `json:"disable_ssl"`
+	DefaultCredentials bool   `json:"default_credentials"`
 
 	URI        string `json:"uri"`
 	Branch     string `json:"branch"`


### PR DESCRIPTION
When running concourse workers in EC2, you can associate an IAM role with those instances, allowing the workers to perform AWS operations without specifying credentials in pipelines. However, the semver-resource forces the credentials to be anonymous if they are not specified. This PR adds a boolean configuration option "default_credentials" which when true and AWS credentials are not specified in the resource, will use the default credentials chain, and allow the worker to use the IAM profile. Doing it in this way preserves backward compatibility.