### PR TITLE
Document version file - Obvious Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Detects new versions by reading the file from the specified source. If the file 
 
 ### `in`: Provide the version as a file, optionally bumping it.
 
-Provides the version number to the build as a `number` file in the destination.
+Provides the version number to the build in files named `number` and `version` in the destination.
 
 Can be configured to bump the version locally, which can be useful for getting
 the `final` version ahead of time when building artifacts.


### PR DESCRIPTION
Documents that the `in` provides the version in two files as per https://www.pivotaltracker.com/n/projects/1059262/stories/93919260