### PR TITLE
Add new `skip_ssl_verification` param to git driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ The `git` driver works by modifying a file in a repository with every bump. The
 
 * `password`: *Optional.* Password for HTTP(S) auth when pulling/pushing.
 
+* `skip_ssl_verification`: *Optional.* Skips git ssl verification by exporting
+  `GIT_SSL_NO_VERIFY=true`.
+
 * `git_user`: *Optional.* The git identity to use when pushing to the
   repository support RFC 5322 address of the form "Gogh Fir \<gf@example.com\>" or "foo@example.com".
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -72,15 +72,16 @@ func FromSource(source models.Source) (Driver, error) {
 
 	case models.DriverGit:
 		return &GitDriver{
-			InitialVersion: initialVersion,
+			InitialVersion:      initialVersion,
 
-			URI:        source.URI,
-			Branch:     source.Branch,
-			PrivateKey: source.PrivateKey,
-			Username:   source.Username,
-			Password:   source.Password,
-			File:       source.File,
-			GitUser:    source.GitUser,
+			URI:                 source.URI,
+			Branch:              source.Branch,
+			PrivateKey:          source.PrivateKey,
+			Username:            source.Username,
+			Password:            source.Password,
+			File:                source.File,
+			GitUser:             source.GitUser,
+			SkipSslVerification: source.SkipSslVerification,
 		}, nil
 
 	case models.DriverSwift:

--- a/driver/git.go
+++ b/driver/git.go
@@ -29,13 +29,14 @@ func init() {
 type GitDriver struct {
 	InitialVersion semver.Version
 
-	URI        string
-	Branch     string
-	PrivateKey string
-	Username   string
-	Password   string
-	File       string
-	GitUser    string
+	URI                 string
+	Branch              string
+	PrivateKey          string
+	Username            string
+	Password            string
+	File                string
+	GitUser             string
+	SkipSslVerification bool
 }
 
 func (driver *GitDriver) Bump(bump version.Bump) (semver.Version, error) {
@@ -135,6 +136,12 @@ func (driver *GitDriver) Check(cursor *semver.Version) ([]semver.Version, error)
 }
 
 func (driver *GitDriver) setUpRepo() error {
+	if (driver.SkipSslVerification) {
+		if err := os.Setenv("GIT_SSL_NO_VERIFY", "true"); err != nil {
+			return err
+		}
+	}
+
 	_, err := os.Stat(gitRepoDir)
 	if err != nil {
 		gitClone := exec.Command("git", "clone", driver.URI, "--branch", driver.Branch, gitRepoDir)

--- a/models/models.go
+++ b/models/models.go
@@ -58,13 +58,14 @@ type Source struct {
 	Endpoint        string `json:"endpoint"`
 	DisableSSL      bool   `json:"disable_ssl"`
 
-	URI        string `json:"uri"`
-	Branch     string `json:"branch"`
-	PrivateKey string `json:"private_key"`
-	Username   string `json:"username"`
-	Password   string `json:"password"`
-	File       string `json:"file"`
-	GitUser    string `json:"git_user"`
+	URI                 string `json:"uri"`
+	Branch              string `json:"branch"`
+	PrivateKey          string `json:"private_key"`
+	Username            string `json:"username"`
+	Password            string `json:"password"`
+	File                string `json:"file"`
+	GitUser             string `json:"git_user"`
+	SkipSslVerification bool   `json:"skip_ssl_verification"`
 
 	OpenStack OpenStackOptions `json:"openstack"`
 }

--- a/test/check.sh
+++ b/test/check.sh
@@ -47,6 +47,28 @@ it_fails_if_key_has_password() {
   grep "private keys with passphrases are not supported" $failed_output
 }
 
+it_can_check_skipping_ssl_verification() {
+  local repo=$(init_repo)
+
+  local fake_bin_dir=$TMPDIR/fake_bin
+  local fake_git_bin=$fake_bin_dir/fake_git
+  mkdir -p $(dirname $fake_bin_dir)
+  echo 'echo GIT_SSL_NO_VERIFY=$GIT_SSL_NO_VERIFY' > $fake_git_bin
+  chmod a+x $fake_git_bin
+
+  # add our fake bin to path
+  old_PATH=$PATH
+  export PATH=$fake_bin_dir:$PATH
+
+  local git_output=$TMPDIR/git-output
+  check_uri_skipping_ssl_verification $repo > $git_output
+
+  # restore path
+  export PATH=$old_PATH
+
+  [ "$(cat $git_output)" = 'GIT_SSL_NO_VERIFY=true' ]
+}
+
 it_can_check_with_credentials() {
   local repo=$(init_repo)
 

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -86,6 +86,18 @@ check_uri_with_initial() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_skipping_ssl_verification() {
+  jq -n "{
+    source: {
+      driver: \"git\",
+      uri: $(echo $1 | jq -R .),
+      branch: \"master\",
+      file: \"some-file\",
+      skip_ssl_verification: true
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 
 check_uri_with_key() {
   jq -n "{


### PR DESCRIPTION
Hi concourse folks,

This PR implements a new `skip_ssl_verification` param that is useful in internal environments where certificates are signed by an internal Root Certificate Authority.

In terms of tests, this new flag is tested by resource tests, but not covered yet by Ginkgo tests.

The resulting enhanced `semver-resource` is built on Gstack Concourse CI (which is private, sorry) and published as [gstack/semver-resource](https://hub.docker.com/r/gstack/semver-resource/). It can be used with the following snippet:

```yaml
resource_types:
  - name: enhanced-semver
    type: docker-image
    source:
      repository: gstack/semver-resource
```

This resource is used by the CloudStack stemcell pipeline (currently WIP). It proved to work properly.

/Benjamin
