### PR TITLE
Add skip_ssl_validation to git driver

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -74,13 +74,14 @@ func FromSource(source models.Source) (Driver, error) {
 		return &GitDriver{
 			InitialVersion: initialVersion,
 
-			URI:        source.URI,
-			Branch:     source.Branch,
-			PrivateKey: source.PrivateKey,
-			Username:   source.Username,
-			Password:   source.Password,
-			File:       source.File,
-			GitUser:    source.GitUser,
+			URI:               source.URI,
+			Branch:            source.Branch,
+			PrivateKey:        source.PrivateKey,
+			Username:          source.Username,
+			Password:          source.Password,
+			File:              source.File,
+			GitUser:           source.GitUser,
+			SkipSslValidation: source.SkipSslValidation,
 		}, nil
 
 	case models.DriverSwift:

--- a/driver/git.go
+++ b/driver/git.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/blang/semver"
@@ -29,13 +30,14 @@ func init() {
 type GitDriver struct {
 	InitialVersion semver.Version
 
-	URI        string
-	Branch     string
-	PrivateKey string
-	Username   string
-	Password   string
-	File       string
-	GitUser    string
+	URI               string
+	Branch            string
+	PrivateKey        string
+	Username          string
+	Password          string
+	File              string
+	GitUser           string
+	SkipSslValidation bool
 }
 
 func (driver *GitDriver) Bump(bump version.Bump) (semver.Version, error) {
@@ -228,7 +230,7 @@ func (driver *GitDriver) setUpUsernamePassword() error {
 		}
 	}
 
-	return nil
+	return os.Setenv("GIT_SSL_NO_VERIFY", strconv.FormatBool(driver.SkipSslValidation))
 }
 
 func (driver *GitDriver) setUserInfo() error {

--- a/models/models.go
+++ b/models/models.go
@@ -58,13 +58,14 @@ type Source struct {
 	Endpoint        string `json:"endpoint"`
 	DisableSSL      bool   `json:"disable_ssl"`
 
-	URI        string `json:"uri"`
-	Branch     string `json:"branch"`
-	PrivateKey string `json:"private_key"`
-	Username   string `json:"username"`
-	Password   string `json:"password"`
-	File       string `json:"file"`
-	GitUser    string `json:"git_user"`
+	URI               string `json:"uri"`
+	Branch            string `json:"branch"`
+	PrivateKey        string `json:"private_key"`
+	Username          string `json:"username"`
+	Password          string `json:"password"`
+	File              string `json:"file"`
+	GitUser           string `json:"git_user"`
+	SkipSslValidation bool   `json:"skip_ssl_validation"`
 
 	OpenStack OpenStackOptions `json:"openstack"`
 }


### PR DESCRIPTION
This will allow users who have a git server without SSH access and self-signed certs use the `git` driver for the semver resource.