### PR TITLE
Remove leading/trailing spaces from s3 body

### DIFF
--- a/driver/s3.go
+++ b/driver/s3.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -34,7 +35,8 @@ func (driver *S3Driver) Bump(bump version.Bump) (semver.Version, error) {
 		}
 		defer resp.Body.Close()
 
-		currentVersion, err = semver.Parse(string(bucketNumberPayload))
+		payloadStr := strings.TrimSpace(string(bucketNumberPayload))
+		currentVersion, err = semver.Parse(payloadStr)
 		if err != nil {
 			return semver.Version{}, err
 		}


### PR DESCRIPTION
If there are any spaces in the s3 file body (for example, if there's a trailing newline), it fails to parse the semver. This resolves that.