### PR TITLE
SSE support for S3 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ the bucket.
 
 * `disable_ssl`: *Optional.* Disable SSL for the endpoint, useful for S3 compatible providers without SSL.
 
-* `server_side_encryption`: *Optional.* The Server-side encryption algorithm 
+* `server_side_encryption`: *Optional.* The server-side encryption algorithm 
 used when storing the version object (e.g. `AES256`, `aws:kms`).
 
 ### `swift` Driver

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ the bucket.
 
 * `disable_ssl`: *Optional.* Disable SSL for the endpoint, useful for S3 compatible providers without SSL.
 
+* `server_side_encryption`: *Optional.* The Server-side encryption algorithm 
+used when storing the version object (e.g. `AES256`, `aws:kms`).
+
 ### `swift` Driver
 
 The `swift` driver works by modifying a file in a container.

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -105,11 +105,12 @@ var _ = Describe("Check", func() {
 
 		putVersion := func(version string) {
 			_, err := svc.PutObject(&s3.PutObjectInput{
-				Bucket:      aws.String(bucketName),
-				Key:         aws.String(key),
-				ContentType: aws.String("text/plain"),
-				Body:        bytes.NewReader([]byte(version)),
-				ACL:         aws.String(s3.ObjectCannedACLPrivate),
+				Bucket:               aws.String(bucketName),
+				Key:                  aws.String(key),
+				ContentType:          aws.String("text/plain"),
+				Body:                 bytes.NewReader([]byte(version)),
+				ACL:                  aws.String(s3.ObjectCannedACLPrivate),
+				ServerSideEncryption: aws.String("AES256"),
 			})
 			Expect(err).NotTo(HaveOccurred())
 		}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -65,9 +65,10 @@ func FromSource(source models.Source) (Driver, error) {
 		return &S3Driver{
 			InitialVersion: initialVersion,
 
-			Svc:        svc,
-			BucketName: source.Bucket,
-			Key:        source.Key,
+			Svc:                  svc,
+			BucketName:           source.Bucket,
+			Key:                  source.Key,
+                        ServerSideEncryption: source.ServerSideEncryption
 		}, nil
 
 	case models.DriverGit:

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -68,7 +68,7 @@ func FromSource(source models.Source) (Driver, error) {
 			Svc:                  svc,
 			BucketName:           source.Bucket,
 			Key:                  source.Key,
-                        ServerSideEncryption: source.ServerSideEncryption
+			ServerSideEncryption: source.ServerSideEncryption,
 		}, nil
 
 	case models.DriverGit:

--- a/driver/s3.go
+++ b/driver/s3.go
@@ -16,9 +16,10 @@ import (
 type S3Driver struct {
 	InitialVersion semver.Version
 
-	Svc        *s3.S3
-	BucketName string
-	Key        string
+	Svc                  *s3.S3
+	BucketName           string
+	Key                  string
+        ServerSideEncryption string
 }
 
 func (driver *S3Driver) Bump(bump version.Bump) (semver.Version, error) {
@@ -58,12 +59,16 @@ func (driver *S3Driver) Bump(bump version.Bump) (semver.Version, error) {
 
 func (driver *S3Driver) Set(newVersion semver.Version) error {
 	params := &s3.PutObjectInput{
-		Bucket:      aws.String(driver.BucketName),
-		Key:         aws.String(driver.Key),
-		ContentType: aws.String("text/plain"),
-		Body:        bytes.NewReader([]byte(newVersion.String())),
-		ACL:         aws.String(s3.ObjectCannedACLPrivate),
+		Bucket:               aws.String(driver.BucketName),
+		Key:                  aws.String(driver.Key),
+		ContentType:          aws.String("text/plain"),
+		Body:                 bytes.NewReader([]byte(newVersion.String())),
+		ACL:                  aws.String(s3.ObjectCannedACLPrivate),
 	}
+
+        if len(driver.ServerSideEncryption) > 0 {
+            params.ServerSideEncryption = aws.String(driver.ServerSideEncryption)
+        }
 
 	_, err := driver.Svc.PutObject(params)
 	return err

--- a/driver/s3.go
+++ b/driver/s3.go
@@ -19,7 +19,7 @@ type S3Driver struct {
 	Svc                  *s3.S3
 	BucketName           string
 	Key                  string
-        ServerSideEncryption string
+	ServerSideEncryption string
 }
 
 func (driver *S3Driver) Bump(bump version.Bump) (semver.Version, error) {
@@ -59,11 +59,11 @@ func (driver *S3Driver) Bump(bump version.Bump) (semver.Version, error) {
 
 func (driver *S3Driver) Set(newVersion semver.Version) error {
 	params := &s3.PutObjectInput{
-		Bucket:               aws.String(driver.BucketName),
-		Key:                  aws.String(driver.Key),
-		ContentType:          aws.String("text/plain"),
-		Body:                 bytes.NewReader([]byte(newVersion.String())),
-		ACL:                  aws.String(s3.ObjectCannedACLPrivate),
+		Bucket:      aws.String(driver.BucketName),
+		Key:         aws.String(driver.Key),
+		ContentType: aws.String("text/plain"),
+		Body:        bytes.NewReader([]byte(newVersion.String())),
+		ACL:         aws.String(s3.ObjectCannedACLPrivate),
 	}
 
         if len(driver.ServerSideEncryption) > 0 {

--- a/models/models.go
+++ b/models/models.go
@@ -57,7 +57,7 @@ type Source struct {
 	RegionName           string `json:"region_name"`
 	Endpoint             string `json:"endpoint"`
 	DisableSSL           bool   `json:"disable_ssl"`
-        ServerSideEncryption string `json:"server_side_encryption"`
+	ServerSideEncryption string `json:"server_side_encryption"`
 
 	URI        string `json:"uri"`
 	Branch     string `json:"branch"`

--- a/models/models.go
+++ b/models/models.go
@@ -50,13 +50,14 @@ type Source struct {
 
 	InitialVersion string `json:"initial_version"`
 
-	Bucket          string `json:"bucket"`
-	Key             string `json:"key"`
-	AccessKeyID     string `json:"access_key_id"`
-	SecretAccessKey string `json:"secret_access_key"`
-	RegionName      string `json:"region_name"`
-	Endpoint        string `json:"endpoint"`
-	DisableSSL      bool   `json:"disable_ssl"`
+	Bucket               string `json:"bucket"`
+	Key                  string `json:"key"`
+	AccessKeyID          string `json:"access_key_id"`
+	SecretAccessKey      string `json:"secret_access_key"`
+	RegionName           string `json:"region_name"`
+	Endpoint             string `json:"endpoint"`
+	DisableSSL           bool   `json:"disable_ssl"`
+        ServerSideEncryption string `json:"server_side_encryption"`
 
 	URI        string `json:"uri"`
 	Branch     string `json:"branch"`

--- a/out/out_test.go
+++ b/out/out_test.go
@@ -66,11 +66,12 @@ var _ = Describe("Out", func() {
 			request = models.OutRequest{
 				Version: models.Version{},
 				Source: models.Source{
-					Bucket:          bucketName,
-					Key:             key,
-					AccessKeyID:     accessKeyID,
-					SecretAccessKey: secretAccessKey,
-					RegionName:      regionName,
+					Bucket:               bucketName,
+					Key:                  key,
+					AccessKeyID:          accessKeyID,
+					SecretAccessKey:      secretAccessKey,
+					RegionName:           regionName,
+                                        ServerSideEncryption: "AES256",
 				},
 				Params: models.OutParams{},
 			}
@@ -119,11 +120,12 @@ var _ = Describe("Out", func() {
 
 		putVersion := func(version string) {
 			_, err := svc.PutObject(&s3.PutObjectInput{
-				Bucket:      aws.String(bucketName),
-				Key:         aws.String(key),
-				ContentType: aws.String("text/plain"),
-				Body:        bytes.NewReader([]byte(version)),
-				ACL:         aws.String(s3.ObjectCannedACLPrivate),
+				Bucket:               aws.String(bucketName),
+				Key:                  aws.String(key),
+				ContentType:          aws.String("text/plain"),
+				Body:                 bytes.NewReader([]byte(version)),
+				ACL:                  aws.String(s3.ObjectCannedACLPrivate),
+				ServerSideEncryption: aws.String("AES256"),
 			})
 			Expect(err).NotTo(HaveOccurred())
 		}

--- a/out/out_test.go
+++ b/out/out_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Out", func() {
 					AccessKeyID:          accessKeyID,
 					SecretAccessKey:      secretAccessKey,
 					RegionName:           regionName,
-                                        ServerSideEncryption: "AES256",
+					ServerSideEncryption: "AES256",
 				},
 				Params: models.OutParams{},
 			}


### PR DESCRIPTION
We require server-side encryption for our CI buckets, so just implementing an optional new `server_side_encryption` string parameter.