### PR TITLE
Change shebang to use Bourne Again Shell as opposed to Bourne shell

### DIFF
--- a/test/all.sh
+++ b/test/all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/test/check.sh
+++ b/test/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e -u
 

--- a/test/put.sh
+++ b/test/put.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
This is because commands like `source` and `set -o pipefail` are not supported by Bourne shell. This causes failure when running tests on systems that do not use Bourne Again Shell for `/bin/sh`.