### PR TITLE
adding support for v2 signing for s3 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ the bucket.
 * `server_side_encryption`: *Optional.* The server-side encryption algorithm
 used when storing the version object (e.g. `AES256`, `aws:kms`).
 
+* `use_v2_signing`: *Optional.* Use v2 signing, default false.
+
 ### `swift` Driver
 
 The `swift` driver works by modifying a file in a container.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -62,6 +62,10 @@ func FromSource(source models.Source) (Driver, error) {
 
 		svc := s3.New(session.New(awsConfig))
 
+		if source.UseV2Signing {
+			setv2Handlers(svc)
+		}
+
 		return &S3Driver{
 			InitialVersion: initialVersion,
 

--- a/driver/v2signer.go
+++ b/driver/v2signer.go
@@ -1,0 +1,212 @@
+package driver
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/corehandlers"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+const (
+	signatureVersion = "2"
+	signatureMethod  = "HmacSHA1"
+	timeFormat       = "2006-01-02T15:04:05Z"
+)
+
+type signer struct {
+	// Values that must be populated from the request
+	Request     *http.Request
+	Time        time.Time
+	Credentials *credentials.Credentials
+	Debug       aws.LogLevelType
+	Logger      aws.Logger
+
+	Query        url.Values
+	stringToSign string
+	signature    string
+}
+
+var s3ParamsToSign = map[string]bool{
+	"acl":                          true,
+	"location":                     true,
+	"logging":                      true,
+	"notification":                 true,
+	"partNumber":                   true,
+	"policy":                       true,
+	"requestPayment":               true,
+	"torrent":                      true,
+	"uploadId":                     true,
+	"uploads":                      true,
+	"versionId":                    true,
+	"versioning":                   true,
+	"versions":                     true,
+	"response-content-type":        true,
+	"response-content-language":    true,
+	"response-expires":             true,
+	"response-cache-control":       true,
+	"response-content-disposition": true,
+	"response-content-encoding":    true,
+	"website":                      true,
+	"delete":                       true,
+}
+
+func setv2Handlers(svc *s3.S3) {
+	svc.Handlers.Build.PushBack(func(r *request.Request) {
+		parsedURL, err := url.Parse(r.HTTPRequest.URL.String())
+		if err != nil {
+			log.Fatal("Failed to parse URL", err)
+		}
+		r.HTTPRequest.URL.Opaque = parsedURL.Path
+	})
+
+	svc.Handlers.Sign.Clear()
+	svc.Handlers.Sign.PushBack(Sign)
+	svc.Handlers.Sign.PushBackNamed(corehandlers.BuildContentLengthHandler)
+}
+
+// Sign requests with signature version 2.
+//
+// Will sign the requests with the service config's Credentials object
+// Signing is skipped if the credentials is the credentials.AnonymousCredentials
+// object.
+func Sign(req *request.Request) {
+	// If the request does not need to be signed ignore the signing of the
+	// request if the AnonymousCredentials object is used.
+	if req.Config.Credentials == credentials.AnonymousCredentials {
+		return
+	}
+
+	v2 := signer{
+		Request:     req.HTTPRequest,
+		Time:        req.Time,
+		Credentials: req.Config.Credentials,
+		Debug:       req.Config.LogLevel.Value(),
+		Logger:      req.Config.Logger,
+	}
+
+	req.Error = v2.Sign()
+
+	if req.Error != nil {
+		return
+	}
+}
+
+func (v2 *signer) Sign() error {
+	credValue, err := v2.Credentials.Get()
+	if err != nil {
+		return err
+	}
+	accessKey := credValue.AccessKeyID
+	var (
+		md5, ctype, date, xamz string
+		xamzDate               bool
+		sarray                 []string
+	)
+
+	headers := v2.Request.Header
+	params := v2.Request.URL.Query()
+	parsedURL, err := url.Parse(v2.Request.URL.String())
+	if err != nil {
+		return err
+	}
+	host, canonicalPath := parsedURL.Host, parsedURL.Path
+	v2.Request.Header["Host"] = []string{host}
+	v2.Request.Header["x-amz-date"] = []string{v2.Time.In(time.UTC).Format(time.RFC1123)}
+
+	for k, v := range headers {
+		k = strings.ToLower(k)
+		switch k {
+		case "content-md5":
+			md5 = v[0]
+		case "content-type":
+			ctype = v[0]
+		case "date":
+			if !xamzDate {
+				date = v[0]
+			}
+		default:
+			if strings.HasPrefix(k, "x-amz-") {
+				vall := strings.Join(v, ",")
+				sarray = append(sarray, k+":"+vall)
+				if k == "x-amz-date" {
+					xamzDate = true
+					date = ""
+				}
+			}
+		}
+	}
+	if len(sarray) > 0 {
+		sort.StringSlice(sarray).Sort()
+		xamz = strings.Join(sarray, "\n") + "\n"
+	}
+
+	expires := false
+	if v, ok := params["Expires"]; ok {
+		expires = true
+		date = v[0]
+		params["AWSAccessKeyId"] = []string{accessKey}
+	}
+
+	sarray = sarray[0:0]
+	for k, v := range params {
+		if s3ParamsToSign[k] {
+			for _, vi := range v {
+				if vi == "" {
+					sarray = append(sarray, k)
+				} else {
+					sarray = append(sarray, k+"="+vi)
+				}
+			}
+		}
+	}
+	if len(sarray) > 0 {
+		sort.StringSlice(sarray).Sort()
+		canonicalPath = canonicalPath + "?" + strings.Join(sarray, "&")
+	}
+
+	v2.stringToSign = strings.Join([]string{
+		v2.Request.Method,
+		md5,
+		ctype,
+		date,
+		xamz + canonicalPath,
+	}, "\n")
+	hash := hmac.New(sha1.New, []byte(credValue.SecretAccessKey))
+	hash.Write([]byte(v2.stringToSign))
+	v2.signature = base64.StdEncoding.EncodeToString(hash.Sum(nil))
+
+	if expires {
+		params["Signature"] = []string{string(v2.signature)}
+	} else {
+		headers["Authorization"] = []string{"AWS " + accessKey + ":" + string(v2.signature)}
+	}
+
+	if v2.Debug.Matches(aws.LogDebugWithSigning) {
+		v2.logSigningInfo()
+	}
+	return nil
+}
+
+const logSignInfoMsg = `DEBUG: Request Signature:
+---[ STRING TO SIGN ]--------------------------------
+%s
+---[ SIGNATURE ]-------------------------------------
+%s
+-----------------------------------------------------`
+
+func (v2 *signer) logSigningInfo() {
+	msg := fmt.Sprintf(logSignInfoMsg, v2.stringToSign, v2.signature)
+	v2.Logger.Log(msg)
+}

--- a/models/models.go
+++ b/models/models.go
@@ -58,6 +58,7 @@ type Source struct {
 	Endpoint             string `json:"endpoint"`
 	DisableSSL           bool   `json:"disable_ssl"`
 	ServerSideEncryption string `json:"server_side_encryption"`
+	UseV2Signing         bool   `json:"use_v2_signing"`
 
 	URI        string `json:"uri"`
 	Branch     string `json:"branch"`


### PR DESCRIPTION
adding the same support for s3 driver that s3-resource has for enabling this resource to be used where v2 signing is still required.  Tested on older version of openstack ceph s3.