### PR TITLE
Add mention to version being cache in the resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ The `git` driver works by modifying a file in a repository with every bump. The
 
 * `depth`: *Optional.* If a positive integer is given, shallow clone the repository using the --depth option.
 
+The version will be cached by the resource. If you wish to change it manually, you will 
+need to delete `file` from the repository and update the source with a new `initial_version` 
+configuration.
+
 ### `s3` Driver
 
 The `s3` driver works by modifying a file in an S3 compatible bucket.


### PR DESCRIPTION
With git driver, manually updating the version value from the version file
does not magically update the next version that will be used since the
ongoing version is cached in the concourse resource.