### PR TITLE
Update parameter name in swift docs to match code

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The `swift` driver works by modifying a file in a container.
   * `item_name`: *Required.* The item name to use for the object in the container tracking
 the version.
 
-  * `region_name`: *Required.* The region the container is in.
+  * `region`: *Required.* The region the container is in.
 
   * `identity_endpoint`, `username`, `user_id`, `password`, `api_key`, `domain_id`, `domain_name`, `tenant_id`, `tenant_name`, `allow_reauth`, `token_id`: See below
 The swift driver uses [gophercloud](http://gophercloud.io/docs/) to handle interacting


### PR DESCRIPTION
The swift driver expects region, not region_name.