### PR TITLE
Updated Git Driver Check to account for OpenSSH formatted keys

### DIFF
--- a/driver/git.go
+++ b/driver/git.go
@@ -201,7 +201,7 @@ func (driver *GitDriver) setUpAuth() error {
 }
 
 func (driver *GitDriver) setUpKey() error {
-	if strings.Contains(driver.PrivateKey, "ENCRYPTED") {
+	if isPrivateKeyEncrypted() {
 		return ErrEncryptedKey
 	}
 
@@ -218,6 +218,14 @@ func (driver *GitDriver) setUpKey() error {
 	}
 
 	return os.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no -i "+privateKeyPath)
+}
+
+func isPrivateKeyEncrypted() bool {
+	passphrase := ``
+	cmd := exec.Command(`ssh-keygen`, `-y`, `-f`, privateKeyPath, `-P`, passphrase)
+	err := cmd.Run()
+
+	return err != nil
 }
 
 func (driver *GitDriver) setUpUsernamePassword() error {


### PR DESCRIPTION
In reference to: https://github.com/concourse/semver-resource/issues/76

Again, we couldn't really find any unit tests for the `GitDriver` itself to modify, but we can add those as well for this change if needed. 