### PR TITLE
Add clarification to pre param

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ be one of:
   type, (e.g. `alpha` vs. `beta`), the type is switched and the prerelease
   version is reset to `1`. If the version is *not* already a pre-release, then
   `pre` is added, starting at `1`.
+  
+  The value of `pre` can be anything you like; the value will be `pre`-pended (_hah_) to a numeric value. For example, `pre: build` will result in a semver of `x.y.z-build.<number>`, `pre: alpha` becomes `x.y.z-alpha.<number>`, and `pre: my-preferred-naming-convention` becomes `x.y.z-my-preferred-naming-convention.<number>`
 
 ### Running the tests
 


### PR DESCRIPTION
As a pipeline plumber, I'd like to know how my pipelines can use the `x.y.z-build.*` semver scheme. 

The current documentation is fuzzy (see [#68]) and makes it sound like `alpha`, `beta`, or `rc` are the only `pre` options. However, it turns out you can use _any_ convention you'd like. Example:

```yml
jobs:
- name: build
  plan:
  - get: version
    params:
      pre: build # <---- x.y.z-build.*
...
  - get: version
    params:
      pre: my-amazing-string-prefix-convention # <--- x.y.z-my-amazing-string-prefix-convention.1
```

Although _any_ string prefix can be used, maybe it shouldn't be advertised. Maybe only semi-conventional naming setups should be advertised, such as `alpha`, `beta`, `rc`, and `build`

See [#68].