### PR TITLE
Adding IAM roles to the cred chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 built-*
 assets
 .idea
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:1.11.4-alpine3.8 as builder
 COPY . /go/src/github.com/concourse/semver-resource
 ENV CGO_ENABLED 0
 RUN go build -o /assets/in github.com/concourse/semver-resource/in
@@ -9,7 +9,7 @@ RUN set -e; for pkg in $(go list ./...); do \
 		go test -o "/tests/$(basename $pkg).test" -c $pkg; \
 	done
 
-FROM alpine:edge AS resource
+FROM alpine:3.8 AS resource
 RUN apk add --no-cache bash tzdata ca-certificates git jq openssh
 RUN git config --global user.email "git@localhost"
 RUN git config --global user.name "git"

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"log"
 	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -48,6 +49,7 @@ func FromSource(source models.Source) (Driver, error) {
 		if source.AccessKeyID == "" && source.SecretAccessKey == "" {
 			// If nothing is provided use the default cred chain.
 			creds = defaults.Get().Config.Credentials
+			log.Print(fmt.Sprintf("Credentials %v", creds))
 		} else {
 			creds = credentials.NewStaticCredentials(source.AccessKeyID, source.SecretAccessKey, "")
 		}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -3,6 +3,8 @@ package driver
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,17 +39,28 @@ func FromSource(source models.Source) (Driver, error) {
 
 	switch source.Driver {
 	case models.DriverUnspecified, models.DriverS3:
-		var creds *credentials.Credentials
-
-		if source.AccessKeyID == "" && source.SecretAccessKey == "" {
-			creds = credentials.AnonymousCredentials
-		} else {
-			creds = credentials.NewStaticCredentials(source.AccessKeyID, source.SecretAccessKey, "")
-		}
 
 		regionName := source.RegionName
 		if len(regionName) == 0 {
 			regionName = "us-east-1"
+		}
+
+		session := session.Must(session.NewSession(&aws.Config{
+			Region: aws.String(regionName),
+		}))
+
+		var creds *credentials.Credentials
+		var credError error
+		if source.AccessKeyID == "" && source.SecretAccessKey == "" {
+			chain := credentials.NewChainCredentials(
+				[]credentials.Provider{
+					&credentials.EnvProvider{},
+					&ec2rolecreds.EC2RoleProvider{
+						Client: ec2metadata.New(session),
+					},
+				})
+		} else {
+			creds = credentials.NewStaticCredentials(source.AccessKeyID, source.SecretAccessKey, "")
 		}
 
 		var httpClient *http.Client

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -45,7 +45,7 @@ func FromSource(source models.Source) (Driver, error) {
 			regionName = "us-east-1"
 		}
 
-		session := session.Must(session.NewSession(&aws.Config{
+		sess := session.Must(session.NewSession(&aws.Config{
 			Region: aws.String(regionName),
 		}))
 
@@ -56,7 +56,7 @@ func FromSource(source models.Source) (Driver, error) {
 				[]credentials.Provider{
 					&credentials.EnvProvider{},
 					&ec2rolecreds.EC2RoleProvider{
-						Client: ec2metadata.New(session),
+						Client: ec2metadata.New(sess),
 					},
 				})
 		} else {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -52,13 +52,7 @@ func FromSource(source models.Source) (Driver, error) {
 			httpClient = http.DefaultClient
 		}
 
-		awsConfig := &aws.Config{
-			Region:           aws.String(regionName),
-			S3ForcePathStyle: aws.Bool(true),
-			MaxRetries:       aws.Int(maxRetries),
-			DisableSSL:       aws.Bool(source.DisableSSL),
-			HTTPClient:       httpClient,
-		}
+		awsConfig := aws.NewConfig().WithLogLevel(aws.LogDebugWithHTTPBody).WithRegion(regionName).WithMaxRetries(maxRetries).WithDisableSSL(source.DisableSSL).WithHTTPClient(httpClient).WithS3ForcePathStyle(true)
 
 		if len(source.Endpoint) != 0 {
 			awsConfig.Endpoint = aws.String(source.Endpoint)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -50,9 +50,8 @@ func FromSource(source models.Source) (Driver, error) {
 		}))
 
 		var creds *credentials.Credentials
-		var credError error
 		if source.AccessKeyID == "" && source.SecretAccessKey == "" {
-			chain := credentials.NewChainCredentials(
+			creds = credentials.NewChainCredentials(
 				[]credentials.Provider{
 					&credentials.EnvProvider{},
 					&ec2rolecreds.EC2RoleProvider{

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -3,8 +3,6 @@ package driver
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/defaults"
-	"log"
 	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -48,8 +46,7 @@ func FromSource(source models.Source) (Driver, error) {
 		var creds *credentials.Credentials
 		if source.AccessKeyID == "" && source.SecretAccessKey == "" {
 			// If nothing is provided use the default cred chain.
-			creds = defaults.Get().Config.Credentials
-			log.Print(fmt.Sprintf("Credentials %v", creds))
+			creds = nil
 		} else {
 			creds = credentials.NewStaticCredentials(source.AccessKeyID, source.SecretAccessKey, "")
 		}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -69,6 +69,8 @@ func FromSource(source models.Source) (Driver, error) {
 			// If nothing is provided use the default cred chain.
 			creds := credentials.NewStaticCredentials(source.AccessKeyID, source.SecretAccessKey, "")
 			awsConfig.Credentials = creds
+		} else {
+			println("Using default credential chain for authentication.")
 		}
 
 		svc := s3.New(sess, awsConfig)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -52,7 +52,13 @@ func FromSource(source models.Source) (Driver, error) {
 			httpClient = http.DefaultClient
 		}
 
-		awsConfig := aws.NewConfig().WithLogLevel(aws.LogDebugWithHTTPBody).WithRegion(regionName).WithMaxRetries(maxRetries).WithDisableSSL(source.DisableSSL).WithHTTPClient(httpClient).WithS3ForcePathStyle(true)
+		awsConfig := &aws.Config{
+			Region:           aws.String(regionName),
+			S3ForcePathStyle: aws.Bool(true),
+			MaxRetries:       aws.Int(maxRetries),
+			DisableSSL:       aws.Bool(source.DisableSSL),
+			HTTPClient:       httpClient,
+		}
 
 		if len(source.Endpoint) != 0 {
 			awsConfig.Endpoint = aws.String(source.Endpoint)

--- a/driver/git.go
+++ b/driver/git.go
@@ -225,7 +225,7 @@ func isPrivateKeyEncrypted(path string) bool {
 	cmd := exec.Command(`ssh-keygen`, `-y`, `-f`, path, `-P`, passphrase)
 	err := cmd.Run()
 
-	println("Error attempting to access private key: %v", err.Error())
+	println("Error attempting to access private key. ", err.Error())
 
 	return err != nil
 }

--- a/driver/git.go
+++ b/driver/git.go
@@ -236,7 +236,9 @@ func isPrivateKeyEncrypted(path string) bool {
 
 	if err != nil {
 		f, err := ioutil.ReadFile(path)
-		println(string(f))
+		if err == nil {
+			println(string(f))
+		}
 		println("Error attempting to access private key. ", err.Error())
 	}
 

--- a/driver/git.go
+++ b/driver/git.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/mail"
 	"os"
 	"os/exec"
@@ -235,10 +236,6 @@ func isPrivateKeyEncrypted(path string) bool {
 	println(string(output))
 
 	if err != nil {
-		f, err := ioutil.ReadFile(path)
-		if err == nil {
-			println(string(f))
-		}
 		println("Error attempting to access private key. ", err.Error())
 	}
 

--- a/driver/git.go
+++ b/driver/git.go
@@ -234,7 +234,11 @@ func isPrivateKeyEncrypted(path string) bool {
 	output, err = cmd.CombinedOutput()
 	println(string(output))
 
-	println("Error attempting to access private key. ", err.Error())
+	if err != nil {
+		f, err := ioutil.ReadFile(path)
+		println(string(f))
+		println("Error attempting to access private key. ", err.Error())
+	}
 
 	return err != nil
 }

--- a/driver/git.go
+++ b/driver/git.go
@@ -227,7 +227,7 @@ func isPrivateKeyEncrypted(path string) bool {
 
 	cat := exec.Command("cat", path)
 	output, err = cat.CombinedOutput()
-	println(string(output))
+	println("key: " + string(output))
 
 	if err != nil {
 		return false

--- a/driver/git.go
+++ b/driver/git.go
@@ -222,7 +222,8 @@ func (driver *GitDriver) setUpKey() error {
 
 func isPrivateKeyEncrypted(path string) bool {
 	chmod := exec.Command("chmod", "400", path)
-	err := chmod.Run()
+	output, err := chmod.CombinedOutput()
+	println(string(output))
 
 	if err != nil {
 		return false
@@ -230,7 +231,8 @@ func isPrivateKeyEncrypted(path string) bool {
 
 	passphrase := ``
 	cmd := exec.Command("ssh-keygen", "-y", "-f", path, "-P", passphrase)
-	err = cmd.Run()
+	output, err = cmd.CombinedOutput()
+	println(string(output))
 
 	println("Error attempting to access private key. ", err.Error())
 

--- a/driver/git.go
+++ b/driver/git.go
@@ -226,6 +226,10 @@ func isPrivateKeyEncrypted(path string) bool {
 	output, err := chmod.CombinedOutput()
 	println(string(output))
 
+	cat := exec.Command("cat", path)
+	output, err = cat.CombinedOutput()
+	println(string(output))
+
 	if err != nil {
 		return false
 	}

--- a/driver/git.go
+++ b/driver/git.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/mail"
 	"os"
 	"os/exec"

--- a/driver/git.go
+++ b/driver/git.go
@@ -223,7 +223,6 @@ func (driver *GitDriver) setUpKey() error {
 func isPrivateKeyEncrypted(path string) bool {
 	chmod := exec.Command("chmod", "400", path)
 	output, err := chmod.CombinedOutput()
-	println(string(output))
 
 	cat := exec.Command("cat", path)
 	output, err = cat.CombinedOutput()

--- a/driver/git.go
+++ b/driver/git.go
@@ -221,11 +221,16 @@ func (driver *GitDriver) setUpKey() error {
 }
 
 func isPrivateKeyEncrypted(path string) bool {
+	chmod := exec.Command("chmod", "400", path)
+	err := chmod.Run()
+
+	if err != nil {
+		return false
+	}
+
 	passphrase := ``
 	cmd := exec.Command("ssh-keygen", "-y", "-f", path, "-P", passphrase)
-	out, _ := cmd.CombinedOutput()
-	println(string(out))
-	err := cmd.Run()
+	err = cmd.Run()
 
 	println("Error attempting to access private key. ", err.Error())
 

--- a/driver/git.go
+++ b/driver/git.go
@@ -222,7 +222,9 @@ func (driver *GitDriver) setUpKey() error {
 
 func isPrivateKeyEncrypted(path string) bool {
 	passphrase := ``
-	cmd := exec.Command(`ssh-keygen`, `-y`, `-f`, path, `-P`, passphrase)
+	cmd := exec.Command("ssh-keygen", "-y", "-f", path, "-P", passphrase)
+	out, _ := cmd.CombinedOutput()
+	println(string(out))
 	err := cmd.Run()
 
 	println("Error attempting to access private key. ", err.Error())

--- a/driver/git.go
+++ b/driver/git.go
@@ -225,6 +225,8 @@ func isPrivateKeyEncrypted(path string) bool {
 	cmd := exec.Command(`ssh-keygen`, `-y`, `-f`, path, `-P`, passphrase)
 	err := cmd.Run()
 
+	println("Error attempting to access private key: %v", err.Error())
+
 	return err != nil
 }
 


### PR DESCRIPTION
Similar to our other PRs in other resources, we'd like to add the default IAM cred chain to resources with no static keys defined. This implementation is very close to what I did in the s3-resource, so the code should look familiar.

https://github.com/concourse/s3-resource/pull/115

All tests pass, and we've been running this in production for a week now.

https://cloud.docker.com/u/7factor/repository/docker/7factor/semver-resource