### PR TITLE
Allow files to be used for bump and pre params

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ bootstrapping, i.e. when there is not a version number present in the source.
 * `driver`: *Optional. Default `s3`.* The driver to use for tracking the
   version. Determines where the version is stored.
 
+* `driver_read_only`: *Optional. Default `false`.* Prevents driver from updating
+  defined backing source. This is useful for so that this resource can take input
+  files in a `put` (see `bump_file` and `pre_file`) and produce output files, but
+  not actually permanently bump the version. `driver_read_only` can also be defined
+  as a param to a `put` to override this setting on the resource `source`
+  configuration.
+
 There are four supported drivers, with their own sets of properties for
 configuring them.
 
@@ -187,6 +194,9 @@ One of the following must be specified:
 
 * `bump` and `pre`: *Optional.* See [Version Bumping
   Semantics](#version-bumping-semantics).
+* `bump_file` and `pre_file`: *Optional.* Files containing strings
+  to use for `bump` or `pre`. Specifying either of these will
+  will take precedence over `bump` and `pre` params.
 
 When `bump` and/or `pre` are used, the version bump will be applied atomically,
 if the driver supports it. That is, if we pull down version `N`, and bump to
@@ -217,7 +227,7 @@ be one of:
   type, (e.g. `alpha` vs. `beta`), the type is switched and the prerelease
   version is reset to `1`. If the version is *not* already a pre-release, then
   `pre` is added, starting at `1`.
-  
+
   The value of `pre` can be anything you like; the value will be `pre`-pended (_hah_) to a numeric value. For example, `pre: build` will result in a semver of `x.y.z-build.<number>`, `pre: alpha` becomes `x.y.z-alpha.<number>`, and `pre: my-preferred-naming-convention` becomes `x.y.z-my-preferred-naming-convention.<number>`
 
 ### Running the tests

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -35,6 +35,8 @@ func FromSource(source models.Source) (Driver, error) {
 		initialVersion = semver.Version{Major: 0, Minor: 0, Patch: 0}
 	}
 
+	driverReadOnly := source.DriverReadOnly
+
 	switch source.Driver {
 	case models.DriverUnspecified, models.DriverS3:
 		var creds *credentials.Credentials
@@ -80,6 +82,7 @@ func FromSource(source models.Source) (Driver, error) {
 
 		return &S3Driver{
 			InitialVersion: initialVersion,
+			DriverReadOnly: driverReadOnly,
 
 			Svc:                  svc,
 			BucketName:           source.Bucket,
@@ -90,6 +93,7 @@ func FromSource(source models.Source) (Driver, error) {
 	case models.DriverGit:
 		return &GitDriver{
 			InitialVersion: initialVersion,
+			DriverReadOnly: driverReadOnly,
 
 			URI:           source.URI,
 			Branch:        source.Branch,
@@ -111,6 +115,7 @@ func FromSource(source models.Source) (Driver, error) {
 
 		return &GCSDriver{
 			InitialVersion: initialVersion,
+			DriverReadOnly: driverReadOnly,
 
 			Servicer:   servicer,
 			BucketName: source.Bucket,

--- a/driver/gcs.go
+++ b/driver/gcs.go
@@ -16,6 +16,7 @@ import (
 
 type GCSDriver struct {
 	InitialVersion semver.Version
+	DriverReadOnly bool
 
 	Servicer   IOServicer
 	BucketName string
@@ -34,10 +35,12 @@ func (d *GCSDriver) Bump(b version.Bump) (semver.Version, error) {
 	}
 
 	newVersion := b.Apply(versions[0])
-	err = d.Set(newVersion)
+	if d.DriverReadOnly == false {
+		err = d.Set(newVersion)
 
-	if err != nil {
-		return semver.Version{}, err
+		if err != nil {
+			return semver.Version{}, err
+		}
 	}
 	return newVersion, nil
 }

--- a/driver/git.go
+++ b/driver/git.go
@@ -28,6 +28,7 @@ func init() {
 
 type GitDriver struct {
 	InitialVersion semver.Version
+	DriverReadOnly bool
 
 	URI           string
 	Branch        string
@@ -70,8 +71,12 @@ func (driver *GitDriver) Bump(bump version.Bump) (semver.Version, error) {
 
 		newVersion = bump.Apply(currentVersion)
 
-		wrote, err := driver.writeVersion(newVersion)
-		if wrote {
+		if driver.DriverReadOnly == false {
+			wrote, _ := driver.writeVersion(newVersion)
+			if wrote {
+				break
+			}
+		} else {
 			break
 		}
 	}

--- a/driver/s3.go
+++ b/driver/s3.go
@@ -20,6 +20,7 @@ type Servicer interface {
 
 type S3Driver struct {
 	InitialVersion semver.Version
+	DriverReadOnly bool
 
 	Svc                  Servicer
 	BucketName           string
@@ -54,9 +55,11 @@ func (driver *S3Driver) Bump(bump version.Bump) (semver.Version, error) {
 
 	newVersion := bump.Apply(currentVersion)
 
-	err = driver.Set(newVersion)
-	if err != nil {
-		return semver.Version{}, err
+	if driver.DriverReadOnly == false {
+		err = driver.Set(newVersion)
+		if err != nil {
+			return semver.Version{}, err
+		}
 	}
 
 	return newVersion, nil

--- a/driver/swift.go
+++ b/driver/swift.go
@@ -17,6 +17,7 @@ type SwiftDriver struct {
 	Container          string
 	ItemName           string
 	InitialVersion     semver.Version
+	DriverReadOnly     bool
 	swiftServiceClient *gophercloud.ServiceClient
 }
 
@@ -115,9 +116,11 @@ func (driver *SwiftDriver) Bump(bump version.Bump) (semver.Version, error) {
 	}
 
 	newVersion := bump.Apply(currentVersion)
-	err = driver.Set(newVersion)
-	if err != nil {
-		return semver.Version{}, err
+	if driver.DriverReadOnly == false {
+		err = driver.Set(newVersion)
+		if err != nil {
+			return semver.Version{}, err
+		}
 	}
 
 	return newVersion, nil

--- a/models/models.go
+++ b/models/models.go
@@ -32,10 +32,14 @@ type OutResponse struct {
 }
 
 type OutParams struct {
-	File string `json:"file"`
+	File     string `json:"file"`
+	BumpFile string `json:"bump_file"`
+	PreFile  string `json:"pre_file"`
 
 	Bump string `json:"bump"`
 	Pre  string `json:"pre"`
+
+	DriverReadOnly *bool `json:"driver_read_only"`
 }
 
 type CheckRequest struct {
@@ -46,7 +50,8 @@ type CheckRequest struct {
 type CheckResponse []Version
 
 type Source struct {
-	Driver Driver `json:"driver"`
+	Driver         Driver `json:"driver"`
+	DriverReadOnly bool   `json:"driver_read_only"`
 
 	InitialVersion string `json:"initial_version"`
 

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -157,6 +157,37 @@ put_uri_with_bump() {
   }" | ${resource_dir}/out "$2" | tee /dev/stderr
 }
 
+put_uri_with_bump_read_only() {
+  jq -n "{
+    source: {
+      driver: \"git\",
+      uri: $(echo $1 | jq -R .),
+      branch: \"master\",
+      file: \"some-file\",
+      driver_read_only: true
+    },
+    params: {
+      bump: $(echo $3 | jq -R .),
+      pre: $(echo $4 | jq -R .)
+    }
+  }" | ${resource_dir}/out "$2" | tee /dev/stderr
+}
+
+put_uri_with_bump_with_files() {
+  jq -n "{
+    source: {
+      driver: \"git\",
+      uri: $(echo $1 | jq -R .),
+      branch: \"master\",
+      file: \"some-file\"
+    },
+    params: {
+      bump_file: $(echo $5 | jq -R .),
+      pre_file: $(echo $6 | jq -R .)
+    }
+  }" | ${resource_dir}/out "$2" | tee /dev/stderr
+}
+
 put_uri_with_bump_and_initial() {
   jq -n "{
     source: {


### PR DESCRIPTION
Allowing `bump` and `pre` params to be specified from files follows Concourse convention of passing data between resources by files. This will allow upstream tasks or resources to decide what the bump/pre level of a version should be.

There's a fair amount of copy/paste here. I'm new to golang so I'm not sure what best practices I'm missing about DRY here.

Fixes #75 