### PR TITLE
Allow for alternative refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The `git` driver works by modifying a file in a repository with every bump. The
 
 * `branch`: *Required.* The branch the file lives on.
 
+* `remote_ref`: *Optional.* The name of an alternative ref to find the specified branch.
+
 * `file`: *Required.* The name of the file in the repository.
 
 * `private_key`: *Optional.* The SSH private key to use when pulling from/pushing to to the repository.
@@ -217,7 +219,7 @@ be one of:
   type, (e.g. `alpha` vs. `beta`), the type is switched and the prerelease
   version is reset to `1`. If the version is *not* already a pre-release, then
   `pre` is added, starting at `1`.
-  
+
   The value of `pre` can be anything you like; the value will be `pre`-pended (_hah_) to a numeric value. For example, `pre: build` will result in a semver of `x.y.z-build.<number>`, `pre: alpha` becomes `x.y.z-alpha.<number>`, and `pre: my-preferred-naming-convention` becomes `x.y.z-my-preferred-naming-convention.<number>`
 
 ### Running the tests

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -99,6 +99,7 @@ func FromSource(source models.Source) (Driver, error) {
 			File:          source.File,
 			GitUser:       source.GitUser,
 			CommitMessage: source.CommitMessage,
+			RemoteRef:     source.RemoteRef,
 		}, nil
 
 	case models.DriverSwift:

--- a/models/models.go
+++ b/models/models.go
@@ -69,6 +69,7 @@ type Source struct {
 	File          string `json:"file"`
 	GitUser       string `json:"git_user"`
 	CommitMessage string `json:"commit_message"`
+	RemoteRef     string `json:"remote_ref"`
 
 	OpenStack OpenStackOptions `json:"openstack"`
 

--- a/test/check.sh
+++ b/test/check.sh
@@ -117,10 +117,21 @@ it_can_check_from_a_version() {
   "
 }
 
+it_can_use_a_ref() {
+  local repo=$(init_repo)
+
+  setup_ref $repo myref master 1.2.3
+
+  check_uri_with_ref $repo | jq -e "
+    . == [{number: $(echo 1.2.3 | jq -R .)}]
+  "
+}
+
 run it_can_check_with_no_current_version
 run it_can_check_with_no_current_version_with_initial_set
 run it_can_check_with_current_version
 run it_fails_if_key_has_password
 run it_can_check_with_credentials
 run it_can_check_from_a_version
+run it_can_use_a_ref
 run it_clears_netrc_even_after_errors

--- a/test/put.sh
+++ b/test/put.sh
@@ -177,6 +177,47 @@ it_can_put_and_bump_with_message_and_replace_over_existing_version() {
   test "$(git -C $repo log -n1 --pretty=%B)" = "$expected_message"
 }
 
+it_can_bump_with_ref() {
+  local repo=$(init_repo)
+
+  setup_ref $repo myref master 0.0.1
+
+  local src=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+  echo 1.2.3 > $src/some-new-file
+
+  # cannot push to repo while it's checked out to a branch
+  git -C $repo checkout refs/heads/master
+
+  put_uri_with_ref $repo $src some-new-file | jq -e "
+    .version == {number: \"1.2.3\"}
+  "
+
+  # switch back to master
+  git -C $repo checkout refs/myref/master
+
+  test -e $repo/some-file
+  test "$(cat $repo/some-file)" = 1.2.3
+}
+
+it_can_put_and_bump_first_version_with_ref() {
+  local repo=$(init_repo)
+
+  local src=$(mktemp -d $TMPDIR/put-src.XXXXXX)
+
+  # cannot push to repo while it's checked out to a branch
+  git -C $repo checkout refs/heads/master
+
+  put_uri_with_bump_with_ref $repo $src minor alpha | jq -e "
+    .version == {number: \"0.1.0-alpha.1\"}
+  "
+
+  # switch back to master
+  git -C $repo checkout refs/myref/master
+
+  test -e $repo/some-file
+  test "$(cat $repo/some-file)" = 0.1.0-alpha.1
+}
+
 run it_can_put_and_set_first_version
 run it_can_put_and_set_same_version
 run it_can_put_and_set_over_existing_version
@@ -185,3 +226,5 @@ run it_can_put_and_bump_first_version_with_initial
 run it_can_put_and_bump_over_existing_version
 run it_can_put_and_bump_with_message_over_existing_version
 run it_can_put_and_bump_with_message_and_replace_over_existing_version
+run it_can_bump_with_ref
+run it_can_put_and_bump_first_version_with_ref


### PR DESCRIPTION
We store our semver in a file on a different ref than is standard. This allows the repo to
store the info, but for our semver branch to never show up along side other branches unless
specifically fetched. There's some shuffling that needs to happen between the standard
branching model and using an alternative ref, but this change allows you to simply specify
another ref and use the specified branch from it (which could also be "master").