### PR TITLE
Added skip SSL verification for git driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The `git` driver works by modifying a file in a repository with every bump. The
 
 * `depth`: *Optional.* If a positive integer is given, shallow clone the repository using the --depth option.
 
+* `skip_ssl_verification`: *Optional.* Skip SSL verification for git endpoint. Useful for git compatible providers using self-signed SSL certificates.
+
 * `commit_message`: *Optional.* If specified overides the default commit message with the one provided. The user can use %version% and %file% to get them replaced automatically with the correct values.
 
 ### `s3` Driver

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -91,14 +91,15 @@ func FromSource(source models.Source) (Driver, error) {
 		return &GitDriver{
 			InitialVersion: initialVersion,
 
-			URI:           source.URI,
-			Branch:        source.Branch,
-			PrivateKey:    source.PrivateKey,
-			Username:      source.Username,
-			Password:      source.Password,
-			File:          source.File,
-			GitUser:       source.GitUser,
-			CommitMessage: source.CommitMessage,
+			URI:                    source.URI,
+			Branch:                 source.Branch,
+			PrivateKey:             source.PrivateKey,
+			Username:               source.Username,
+			Password:               source.Password,
+			File:                   source.File,
+			GitUser:                source.GitUser,
+			CommitMessage:          source.CommitMessage,
+			SkipSSLVerification:    source.SkipSSLVerification,
 		}, nil
 
 	case models.DriverSwift:

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -46,3 +46,34 @@ var _ = Describe("Driver", func() {
 		})
 	})
 })
+
+var _ = Describe("Driver", func() {
+	Context("Git", func() {
+		var src models.Source
+		BeforeEach(func() {
+			src = models.Source{
+				Driver: models.DriverGit,
+			}
+		})
+		It("returns a default git driver", func() {
+			aDriver, err := driver.FromSource(src)
+			Expect(err).To(BeNil())
+			Expect(aDriver).ToNot(BeNil())
+			gitDriver, ok := aDriver.(*driver.GitDriver)
+			Expect(ok).To(BeTrue())
+			Expect(gitDriver.SkipSSLVerification).To(Not(BeNil()))
+			Expect(gitDriver.SkipSSLVerification).To(BeFalse())
+		})
+		It("returns a git driver with a transport that ignores ssl verification", func() {
+			src.SkipSSLVerification = true
+			aDriver, err := driver.FromSource(src)
+			Expect(err).To(BeNil())
+			Expect(aDriver).ToNot(BeNil())
+			gitDriver, ok := aDriver.(*driver.GitDriver)
+			Expect(ok).To(BeTrue())
+			Expect(gitDriver.SkipSSLVerification).To(Not(BeNil()))
+			Expect(gitDriver.SkipSSLVerification).To(BeTrue())
+
+		})
+	})
+})

--- a/driver/git.go
+++ b/driver/git.go
@@ -29,15 +29,16 @@ func init() {
 type GitDriver struct {
 	InitialVersion semver.Version
 
-	URI           string
-	Branch        string
-	PrivateKey    string
-	Username      string
-	Password      string
-	File          string
-	GitUser       string
-	Depth         string
-	CommitMessage string
+	URI                 string
+	Branch              string
+	PrivateKey          string
+	Username            string
+	Password            string
+	File                string
+	GitUser             string
+	Depth               string
+	CommitMessage       string
+	SkipSSLVerification bool
 }
 
 func (driver *GitDriver) Bump(bump version.Bump) (semver.Version, error) {
@@ -138,6 +139,14 @@ func (driver *GitDriver) Check(cursor *semver.Version) ([]semver.Version, error)
 
 func (driver *GitDriver) setUpRepo() error {
 	_, err := os.Stat(gitRepoDir)
+	if driver.SkipSSLVerification {
+        gitSkipSSLVerification := exec.Command("git", "config", "http.sslVerify", "'false'")
+        gitSkipSSLVerification.Stdout = os.Stderr
+        gitSkipSSLVerification.Stderr = os.Stderr
+        if err := gitSkipSSLVerification.Run(); err != nil {
+            return err
+        }
+    }
 	if err != nil {
 		gitClone := exec.Command("git", "clone", driver.URI, "--branch", driver.Branch)
 		if len(driver.Depth) > 0 {


### PR DESCRIPTION
I based myself on #50. 

If the option is set, it will run `git config http.sslVerify "false"` in the setUpRepo() method in git.go.

This solves #96. 