### PR TITLE
Support for temporary security credentials, AWS S3 driver

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -42,7 +42,7 @@ func FromSource(source models.Source) (Driver, error) {
 		if source.AccessKeyID == "" && source.SecretAccessKey == "" {
 			creds = credentials.AnonymousCredentials
 		} else {
-			creds = credentials.NewStaticCredentials(source.AccessKeyID, source.SecretAccessKey, "")
+			creds = credentials.NewStaticCredentials(source.AccessKeyID, source.SecretAccessKey, source.SessionToken)
 		}
 
 		regionName := source.RegionName

--- a/models/models.go
+++ b/models/models.go
@@ -54,6 +54,7 @@ type Source struct {
 	Key                  string `json:"key"`
 	AccessKeyID          string `json:"access_key_id"`
 	SecretAccessKey      string `json:"secret_access_key"`
+	SessionToken         string `json:"session_token"`
 	RegionName           string `json:"region_name"`
 	Endpoint             string `json:"endpoint"`
 	DisableSSL           bool   `json:"disable_ssl"`


### PR DESCRIPTION
In order to use generated credentials, the aws session token needs to be set.

https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html

in my case, The https://github.com/telia-oss/concourse-sts-lambda generate & rotate the temporary credentials. so in order for any temporary credentials to be used, we need to set token session.

Thanks