### PR TITLE
Add session_token to params for S3

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -42,7 +42,7 @@ func FromSource(source models.Source) (Driver, error) {
 		if source.AccessKeyID == "" && source.SecretAccessKey == "" {
 			creds = credentials.AnonymousCredentials
 		} else {
-			creds = credentials.NewStaticCredentials(source.AccessKeyID, source.SecretAccessKey, "")
+			creds = credentials.NewStaticCredentials(source.AccessKeyID, source.SecretAccessKey, source.SessionToken)
 		}
 
 		regionName := source.RegionName

--- a/models/models.go
+++ b/models/models.go
@@ -56,6 +56,7 @@ type Source struct {
 	Key                  string `json:"key"`
 	AccessKeyID          string `json:"access_key_id"`
 	SecretAccessKey      string `json:"secret_access_key"`
+	SessionToken         string `json:"session_token"`
 	RegionName           string `json:"region_name"`
 	Endpoint             string `json:"endpoint"`
 	DisableSSL           bool   `json:"disable_ssl"`


### PR DESCRIPTION
This adds a property to the `s3` driver (`session_token`) to allow passing in a session token, required when using temporary AWS credentials.

This would also fix (or, enable the use case in) #16.