### PR TITLE
[swift] make initial version optional

### DIFF
--- a/driver/swift.go
+++ b/driver/swift.go
@@ -58,9 +58,14 @@ func NewSwiftDriver(source *models.Source) (Driver, error) {
 		return nil, fmt.Errorf("Unable to get container by name '%s', inner error: %s", source.OpenStack.Container, err.Error())
 	}
 
-	initialVersion, err := semver.Parse(source.InitialVersion)
-	if err != nil {
-		return nil, fmt.Errorf("Initial version was not a valid sem ver: %s", err.Error())
+	var initialVersion semver.Version
+	if source.InitialVersion != "" {
+		initialVersion, err = semver.Parse(source.InitialVersion)
+		if err != nil {
+			return nil, fmt.Errorf("Initial version was not a valid sem ver: %s", err.Error())
+		}
+	} else {
+		initialVersion = semver.Version{Major: 0, Minor: 0, Patch: 0}
 	}
 
 	driver := &SwiftDriver{

--- a/driver/swift_test.go
+++ b/driver/swift_test.go
@@ -183,6 +183,16 @@ var _ = Describe("Swift", func() {
 		Expect(semVers).To(HaveLen(1))
 		Expect(semVers[0].String()).To(Equal("2.0.10"))
 	})
+
+	It("the initial version is optional", func() {
+		driver, err := newTestSwiftDriver("", "testitem4.txt")
+		defer deleteObject("testitem3.txt")
+		Expect(err).To(BeNil())
+
+		semVers, err := driver.Check(nil)
+		Expect(err).To(BeNil())
+		Expect(semVers).To(HaveLen(0))
+	})
 })
 
 func newTestSwiftDriver(initialVersion string, itemName string) (Driver, error) {

--- a/driver/swift_test.go
+++ b/driver/swift_test.go
@@ -186,7 +186,7 @@ var _ = Describe("Swift", func() {
 
 	It("the initial version is optional", func() {
 		driver, err := newTestSwiftDriver("", "testitem4.txt")
-		defer deleteObject("testitem3.txt")
+		defer deleteObject("testitem4.txt")
 		Expect(err).To(BeNil())
 
 		semVers, err := driver.Check(nil)


### PR DESCRIPTION
Fixes concourse/semver-resource#21

This is the smallest change I could make to fix this issue. I'm unable
to run the "unit" tests because I do not have access (or have
personally worked with) an OpenStack environment.

The swift driver is actually the only driver with a constructor
(`NewABC()`)  function. The other drivers are constructed in
`FromSource()` where there is a copy of the `if..else` this commit adds.