### PR TITLE
Fix unhandled errors in git source and json encoding

### DIFF
--- a/check/main.go
+++ b/check/main.go
@@ -44,7 +44,10 @@ func main() {
 		})
 	}
 
-	json.NewEncoder(os.Stdout).Encode(delta)
+	err = json.NewEncoder(os.Stdout).Encode(delta)
+	if err != nil {
+		fatal("encoding to json", err)
+	}
 }
 
 func fatal(doing string, err error) {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -20,6 +20,7 @@ type Driver interface {
 	Check(*semver.Version) ([]semver.Version, error)
 }
 
+// maxTries is maxRetries + 1
 const maxRetries = 12
 
 func FromSource(source models.Source) (Driver, error) {

--- a/driver/v2signer.go
+++ b/driver/v2signer.go
@@ -184,7 +184,9 @@ func (v2 *signer) Sign() error {
 		xamz + canonicalPath,
 	}, "\n")
 	hash := hmac.New(sha1.New, []byte(credValue.SecretAccessKey))
-	hash.Write([]byte(v2.stringToSign))
+	if _, err := hash.Write([]byte(v2.stringToSign)); err != nil {
+		return err
+	}
 	v2.signature = base64.StdEncoding.EncodeToString(hash.Sum(nil))
 
 	if expires {

--- a/in/main.go
+++ b/in/main.go
@@ -61,12 +61,15 @@ func main() {
 		}
 	}
 
-	json.NewEncoder(os.Stdout).Encode(models.InResponse{
+	err = json.NewEncoder(os.Stdout).Encode(models.InResponse{
 		Version: request.Version,
 		Metadata: models.Metadata{
 			{"number", request.Version.Number},
 		},
 	})
+	if err != nil {
+		fatal("encoding to json", err)
+	}
 }
 
 func fatal(doing string, err error) {

--- a/out/main.go
+++ b/out/main.go
@@ -75,12 +75,15 @@ func main() {
 		Number: newVersion.String(),
 	}
 
-	json.NewEncoder(os.Stdout).Encode(models.OutResponse{
+	err = json.NewEncoder(os.Stdout).Encode(models.OutResponse{
 		Version: outVersion,
 		Metadata: models.Metadata{
 			{"number", outVersion.Number},
 		},
 	})
+	if err != nil {
+		fatal("encoding to json", err)
+	}
 }
 
 func fatal(doing string, err error) {


### PR DESCRIPTION
This fixes some error-handling bugs, including one in Git:Bump which likely resulted in versions being used more than once.