### PR TITLE
handle error from closing GCS writer

### DIFF
--- a/driver/gcs.go
+++ b/driver/gcs.go
@@ -47,9 +47,11 @@ func (d *GCSDriver) Set(v semver.Version) error {
 	if err != nil {
 		return err
 	}
-	defer w.Close()
 	_, err = w.Write([]byte(v.String()))
-	return err
+	if err != nil {
+		return err
+	}
+	return w.Close()
 }
 
 func (d *GCSDriver) Check(cursor *semver.Version) ([]semver.Version, error) {


### PR DESCRIPTION
Sometimes writing the version file to GCS can silently fail and the file is empty after a `put`. The error only surfaces on subsequent `get` or `check` (see https://github.com/concourse/semver-resource/issues/125).

This change no longer ignores errors returned when closing the GCS writer, as the [library docs](https://pkg.go.dev/cloud.google.com/go/storage#Writer.Write) state:

> Since writes happen asynchronously, Write may return a nil error even though the write failed (or will fail). Always use the error returned from Writer.Close to determine if the upload was successful.



