### PR TITLE
Allow `puts` that only bump the build label

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ be one of:
     * Major version bump: version file = 1.2.4-SNAPSHOT, release version = 2.0.0
     * Minor version bump: version file = 1.2.4-SNAPSHOT, release version = 1.3.0
     * Promote snapshot: version file = 1.2.4-SNAPSHOT, release version = 1.2.4
+* `build_without_version`: *Optional.* Same as `pre_without_version` but for
+  build labels.
 
 ### Running the tests
 

--- a/out/main.go
+++ b/out/main.go
@@ -56,7 +56,7 @@ func main() {
 		if err != nil {
 			fatal("setting version", err)
 		}
-	} else if request.Params.Bump != "" || request.Params.Pre != "" {
+	} else if request.Params.Bump != "" || request.Params.Pre != "" || request.Params.Build != "" {
 		bump := version.BumpFromParams(
 			request.Params.Bump,
 			request.Params.Pre,


### PR DESCRIPTION
Follow up to #131 to fix a bug where the resource would error if you tried to do a build label bump with an empty `bump` and `pre`.