### PR TITLE
Add get_latest param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ plan:
 
 ### `check`: Report the current version number.
 
-Detects new versions by reading the file from the specified source. If the file is empty, it returns the `initial_version`. If the file is not empty, it returns the version specified in the file.
+Detects new versions by reading the file from the specified source. If the
+file is empty, it returns the `initial_version`. If the file is not empty, it
+returns the version specified in the file.
 
 ### `in`: Provide the version as a file, optionally bumping it.
 
@@ -205,6 +207,7 @@ because there's some new version `M`, the driver will re-apply the bump to get
 * `pre_without_version`: *Optional.* By default `false`, once it's set to `true` 
 then PreRelease will be bumped without a version number.
 
+* `get_latest`: *Optional.* See [Check-less Usage](#check-less-usage).
 
 ## Version Bumping Semantics
 
@@ -229,7 +232,10 @@ be one of:
   version is reset to `1`. If the version is *not* already a pre-release, then
   `pre` is added, starting at `1`.
 
-  The value of `pre` can be anything you like; the value will be `pre`-pended (_hah_) to a numeric value. For example, `pre: foo` will result in a semver of `x.y.z-foo.<number>`, `pre: alpha` becomes `x.y.z-alpha.<number>`, and `pre: my-preferred-naming-convention` becomes `x.y.z-my-preferred-naming-convention.<number>`
+  The value of `pre` can be anything you like; the value will be `pre`-pended (_hah_)
+  to a numeric value. For example, `pre: foo` will result in a semver of
+  `x.y.z-foo.<number>`, `pre: alpha` becomes `x.y.z-alpha.<number>`, and
+  `pre: my-preferred-naming-convention` becomes `x.y.z-my-preferred-naming-convention.<number>`
 
 * `build`: *Optional.* Same as `pre` but for build labels (e.g. `build: foo`
   will result in a semver of `x.y.z+foo.<number>`, `build: alpha` becomes
@@ -246,7 +252,77 @@ be one of:
 * `build_without_version`: *Optional.* Same as `pre_without_version` but for
   build labels.
 
-### Running the tests
+## Check-less Usage
+
+A classic usage of semver resource is like:
+
+```yaml
+resources:
+- name: version
+  type: semver
+  source:
+    driver: git
+    uri: git@github.com:concourse/concourse.git
+    branch: version
+    file: version
+    private_key: {{concourse-repo-private-key}}
+
+jobs:
+- name: some-job
+  plan:
+  - get: trigger-resource
+    trigger: true
+  - get: version
+    param: {bump: major}
+  - task: a-thing-that-needs-a-version
+  - put: version
+    params: {file: version/version}
+```
+
+In above classic mode, Concourse will run periodic checks against the `semver` 
+resource `version`. Each check will do a `git clone` as the driver is `git`. On
+a large deployment that hosts thousands of pipelines, when there are a lot of
+`semver` resources, checks on `semver` resources may also bring burden to the
+git system as each check will invoke a `git clone`.
+
+Given each `semver` resource requires a parameter `file` in `source`, `semver`
+resources are hard to enjoy [benefits of global resources](https://concourse-ci.org/global-resources.html#benefits-of-global-resources).
+
+To mitigate the burden of checks, if a `semver` resource is not a job trigger,
+check-less mode can be used. The above sample then can be rewritten as:
+
+```yaml
+jobs:
+- name: some-job
+  plan:
+  - get: trigger-resource
+    trigger: true
+  - put: version # change `get` to `put`
+    param:
+      get_latest: true # and set `get_latest: true`
+    get_params:
+      bump: major
+  - task: a-thing-that-needs-a-version
+  - put: version
+    params: {file: version/version}
+```
+
+You may have noticed that, original `get: version` is changed to `put: version`.
+Now resource `version` is put-only, then Concourse will no longer run check on
+it. Param `get_latest: true` tells the `put` step to only fetch the latest version
+without bumping anything. Then the implied `get` will make a bump as the original
+`get: version`.
+
+If your Concourse or Git (e.g. Gitlab) systems are exhausted by `semver` resources' 
+checks, you may consider reforming pipelines to use this check-less usage.
+
+The cons of check-less usage are:
+
+* you cannot use `put` step as a job trigger.
+* `put` step with `get_latest: true` will always fetch the latest version, thus
+  you are not able to pin an old version.
+
+## Running the tests
 
 The tests have been embedded with the `Dockerfile`; ensuring that the testing
 environment is consistent across any `docker` enabled platform. When the docker
@@ -260,7 +336,7 @@ docker build -t semver-resource --target tests -f dockerfiles/alpine/Dockerfile 
 docker build -t semver-resource --target tests -f dockerfiles/ubuntu/Dockerfile .
 ```
 
-#### Integration tests
+### Integration tests
 
 The integration requires two AWS S3 buckets, one without versioning and another
 with. The `docker build` step requires setting `--build-args` so the
@@ -287,7 +363,7 @@ docker build . -t semver-resource --target tests -f dockerfiles/ubuntu/Dockerfil
   --build-arg SEMVER_TESTING_REGION="some-region"
 ```
 
-### Contributing
+## Contributing
 
 Please make all pull requests to the `master` branch and ensure tests pass
 locally.

--- a/README.md
+++ b/README.md
@@ -280,10 +280,9 @@ jobs:
 ```
 
 In above classic mode, Concourse will run periodic checks against the `semver` 
-resource `version`. Each check will do a `git clone` as the driver is `git`. On
-a large deployment that hosts thousands of pipelines, when there are a lot of
-`semver` resources, checks on `semver` resources may also bring burden to the
-git system as each check will invoke a `git clone`.
+resource `version`. Each check will do a `git clone` as the driver is `git`. 
+When there are a lot of `semver` resources, checks on `semver` resources may 
+also bring burden to the git system as each check will invoke a `git clone`.
 
 Given each `semver` resource requires a parameter `file` in `source`, `semver`
 resources are hard to enjoy [benefits of global resources](https://concourse-ci.org/global-resources.html#benefits-of-global-resources).
@@ -310,8 +309,8 @@ jobs:
 You may have noticed that, original `get: version` is changed to `put: version`.
 Now resource `version` is put-only, then Concourse will no longer run check on
 it. Param `get_latest: true` tells the `put` step to only fetch the latest version
-without bumping anything. Then the implied `get` will make a bump as the original
-`get: version`.
+without bumping anything. Then the implied `get` will fetch a version as a typical
+`get` step.
 
 If your Concourse or Git (e.g. Gitlab) systems are exhausted by `semver` resources' 
 checks, you may consider reforming pipelines to use this check-less usage.

--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -5,6 +5,10 @@ FROM ${builder_image} as builder
 COPY . /src
 WORKDIR /src
 ENV CGO_ENABLED 0
+
+ARG goproxy
+ENV GOPROXY=$goproxy
+
 RUN go get -d ./...
 RUN go build -o /assets/in ./in
 RUN go build -o /assets/out ./out

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -5,6 +5,10 @@ FROM ${builder_image} as builder
 COPY . /src
 WORKDIR /src
 ENV CGO_ENABLED 0
+
+ARG goproxy
+ENV GOPROXY=$goproxy
+
 RUN go get -d ./...
 RUN go build -o /assets/in ./in
 RUN go build -o /assets/out ./out

--- a/driver/git.go
+++ b/driver/git.go
@@ -3,7 +3,6 @@ package driver
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/mail"
 	"os"
 	"os/exec"
@@ -225,7 +224,7 @@ func (driver *GitDriver) setUpKey() error {
 	if err != nil {
 		if os.IsNotExist(err) {
 			privateKey := strings.TrimSuffix(driver.PrivateKey, "\n")
-			err := ioutil.WriteFile(privateKeyPath, []byte(privateKey+"\n"), 0600)
+			err := os.WriteFile(privateKeyPath, []byte(privateKey+"\n"), 0600)
 			if err != nil {
 				return err
 			}
@@ -254,7 +253,7 @@ func (driver *GitDriver) setUpUsernamePassword() error {
 	if err != nil {
 		if os.IsNotExist(err) {
 			content := fmt.Sprintf("default login %s password %s", driver.Username, driver.Password)
-			err := ioutil.WriteFile(netRcPath, []byte(content), 0600)
+			err := os.WriteFile(netRcPath, []byte(content), 0600)
 			if err != nil {
 				return err
 			}
@@ -322,8 +321,6 @@ func (driver *GitDriver) readVersion() (semver.Version, bool, error) {
 
 const nothingToCommitString = "nothing to commit"
 const falsePushString = "Everything up-to-date"
-//const pushRejectedString = "[rejected]"
-//const pushRemoteRejectedString = "[remote rejected]"
 
 func (driver *GitDriver) writeVersion(newVersion semver.Version) (bool, error) {
 
@@ -335,7 +332,7 @@ func (driver *GitDriver) writeVersion(newVersion semver.Version) (bool, error) {
 		}
 	}
 
-	err := ioutil.WriteFile(filepath.Join(gitRepoDir, driver.File), []byte(newVersion.String()+"\n"), 0644)
+	err := os.WriteFile(filepath.Join(gitRepoDir, driver.File), []byte(newVersion.String()+"\n"), 0644)
 	if err != nil {
 		return false, err
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -42,6 +42,8 @@ type OutParams struct {
 	Build               string `json:"build"`
 	PreWithoutVersion   bool   `json:"pre_without_version"`
 	BuildWithoutVersion bool   `json:"build_without_version"`
+
+	GetLatest bool `json:"get_latest,omitempty"`
 }
 
 type CheckRequest struct {

--- a/out/main.go
+++ b/out/main.go
@@ -33,7 +33,13 @@ func main() {
 	}
 
 	var newVersion semver.Version
-	if request.Params.File != "" {
+	if request.Params.GetLatest {
+		versions, err := driver.Check(nil)
+		if err != nil {
+			fatal("checking latest version", err)
+		}
+		newVersion = versions[0]
+	} else if request.Params.File != "" {
 		versionFile, err := os.Open(filepath.Join(sources, request.Params.File))
 		if err != nil {
 			fatal("opening version file", err)


### PR DESCRIPTION
Close #124 

---
# Release Note

* Introduced "check-less usage", which avoid to run checks on "semver" resources, which reduces burdens brought to the dependent systems, such as git. Refer to the README for details.
* Fixed a bug (#124) where git push errors were silently discarded. 