### PR TITLE
ensure we don't fetch older, cached versions from GCS

### DIFF
--- a/driver/gcs.go
+++ b/driver/gcs.go
@@ -139,5 +139,7 @@ func (s *GCSIOServicer) PutObject(bucketName, objectName string) (io.WriteCloser
 	bkt := client.Bucket(bucketName)
 	obj := bkt.Object(objectName)
 
-	return obj.NewWriter(context.Background()), nil
+	w := obj.NewWriter(context.Background())
+	w.CacheControl = "private"
+	return w, nil
 }


### PR DESCRIPTION
Closes #61 
Haven't tested this myself. This is a best-effort fix based on the comment in https://github.com/concourse/semver-resource/issues/61#issuecomment-368215508