### PR TITLE
update readme and verify aws creds earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,29 +52,30 @@ The `s3` driver works by modifying a file in an S3 compatible bucket.
 * `key`: *Required.* The key to use for the object in the bucket tracking
 the version.
 
-* `access_key_id`: *Required.* The AWS access key to use when accessing the
+* `access_key_id`: *Optional.* The AWS access key to use when accessing the
 bucket.
 
-* `secret_access_key`: *Required.* The AWS secret key to use when accessing
+* `secret_access_key`: *Optional.* The AWS secret key to use when accessing
 the bucket.
 
-* `assume_role_arn`: *Optional.* The AWS role to assume when using access keys.
+* `assume_role_arn`: *Optional.* The AWS role to assume.
+    Role be assumed using the AWS SDK's default authentication chain. If
+    `access_key_id` and `secret_access_key` are provided, then those
+    credentials will be used to assume the role.
 
 * `session_token`: *Optional.* The AWS session token to use when accessing
 the bucket.
 
 * `region_name`: *Optional. Default `us-east-1`.* The region the bucket is in.
 
-* `endpoint`: *Optional.* Custom endpoint for using S3 compatible provider. Can be a hostname or URL.
+* `endpoint`: *Optional.* Custom endpoint for using S3 compatible provider. Can be a hostname or URL. (e.g. `https://my-endpoint.com` or `my-endpoint.com`)
 
-* `disable_ssl`: *Optional.* Disable SSL for the endpoint, useful for S3 compatible providers without SSL.
+* `disable_ssl`: *Optional.* Disable SSL for the endpoint, useful for S3 compatible providers without SSL. Only used when `endpoint` is set.
 
 * `skip_ssl_verification`: *Optional.* Skip SSL verification for S3 endpoint. Useful for S3 compatible providers using self-signed SSL certificates.
 
 * `server_side_encryption`: *Optional.* The server-side encryption algorithm
-used when storing the version object (e.g. `AES256`, `aws:kms`).
-
-* `use_v2_signing`: *Deprecated.* No longer used after upgrading to v2 of the AWS Go SDK.
+used when storing the version object (e.g. `AES256`, `aws:kms`, `aws:kms:dsse`).
 
 The following IAM permissions are required with a resource ARN like
 `"arn:aws:s3:::BUCKET_NAME/*"`. You could use the exact key instead of `/*` if


### PR DESCRIPTION
also removed the v2 signing stuff. Doubt anyone was using it anyways. All current s3-compatible providers use v4 signing now.

If someone needs v2 signing they can stick with older versions of the resource.