### PR TITLE
feat: add sparse checkout to optimize git operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ The `git` driver works by modifying a file in a repository with every bump. The
 * `git_user`: *Optional.* The git identity to use when pushing to the
   repository support RFC 5322 address of the form "Gogh Fir \<gf@example.com\>" or "foo@example.com".
 
-* `depth`: *Optional.* If a positive integer is given, shallow clone the repository using the --depth option.
-
 * `skip_ssl_verification`: *Optional.* Skip SSL verification for git endpoint. Useful for git compatible providers using self-signed SSL certificates.
 
 * `commit_message`: *Optional.* If specified overides the default commit message with the one provided. The user can use %version% and %file% to get them replaced automatically with the correct values.

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -128,6 +128,17 @@ check_uri_from() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_with_file() {
+  jq -n "{
+    source: {
+      driver: \"git\",
+      uri: $(echo $1 | jq -R .),
+      branch: \"master\",
+      file: $(echo $2 | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 put_uri() {
   jq -n "{
     source: {


### PR DESCRIPTION
Only fetch version file instead of entire repo using sparse checkout. Significantly improves performance for large repositories.

Fixes #119