### PR TITLE
Allow usage of access tokens with the gcs driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ The `gcs` driver works by modifying a file in a Google Cloud Storage bucket.
 
 * `key`: *Required.* The key to use for the object in the bucket tracking the version.
 
-* `json_key`: *Required.* The contents of your GCP Account JSON Key. Example:
+* `json_key`: *Optional.* The contents of your GCP Account JSON Key. One of
+  `json_key` or `token` must be provided. Cannot be used together with `token`.
+  Example:
 
   ```yaml
   json_key: |
@@ -136,6 +138,16 @@ The `gcs` driver works by modifying a file in a Google Cloud Storage bucket.
       "client_id": "...",
       "type": "service_account"
     }
+  ```
+
+* `token`: *Optional.* A GCP OAuth2 access token (e.g. from `gcloud auth
+  print-access-token`). One of `json_key` or `token` must be provided. Cannot
+  be used together with `json_key`. Note that access tokens are short-lived and
+  will expire, so this option is best suited for short-lived pipelines or
+  testing. Example:
+
+  ```yaml
+  token: ya29.c.c0AY...
   ```
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -142,9 +142,8 @@ The `gcs` driver works by modifying a file in a Google Cloud Storage bucket.
 
 * `token`: *Optional.* A GCP OAuth2 access token (e.g. from `gcloud auth
   print-access-token`). One of `json_key` or `token` must be provided. Cannot
-  be used together with `json_key`. Note that access tokens are short-lived and
-  will expire, so this option is best suited for short-lived pipelines or
-  testing. Example:
+  be used together with `json_key`.
+  Example:
 
   ```yaml
   token: ya29.c.c0AY...

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -169,8 +169,17 @@ func FromSource(source models.Source) (Driver, error) {
 		return NewSwiftDriver(&source)
 
 	case models.DriverGCS:
+		if source.JSONKey != "" && source.GCSToken != "" {
+			return nil, fmt.Errorf("must specify only one of json_key or token for the gcs driver")
+		}
+
+		if source.JSONKey == "" && source.GCSToken == "" {
+			return nil, fmt.Errorf("must specify one of json_key or token for the gcs driver")
+		}
+
 		servicer := &GCSIOServicer{
 			JSONCredentials: source.JSONKey,
+			Token:           source.GCSToken,
 		}
 
 		return &GCSDriver{

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -73,8 +73,49 @@ var _ = Describe("Driver", func() {
 			gitDriver, ok := aDriver.(*driver.GitDriver)
 			Expect(ok).To(BeTrue())
 			Expect(gitDriver.SkipSSLVerification).To(Not(BeNil()))
-			Expect(gitDriver.SkipSSLVerification).To(BeTrue())
+		})
+	})
+})
 
+var _ = Describe("Driver", func() {
+	Context("GCS", func() {
+		var src models.Source
+		BeforeEach(func() {
+			src = models.Source{
+				Driver: models.DriverGCS,
+				Bucket: "my-bucket",
+				Key:    "my-key",
+			}
+		})
+		It("returns an error when both json_key and token are provided", func() {
+			src.JSONKey = `{"type": "service_account"}`
+			src.GCSToken = "ya29.some-token"
+			_, err := driver.FromSource(src)
+			Expect(err).To(MatchError("must specify only one of json_key or token for the gcs driver"))
+		})
+		It("returns an error when neither json_key nor token is provided", func() {
+			_, err := driver.FromSource(src)
+			Expect(err).To(MatchError("must specify one of json_key or token for the gcs driver"))
+		})
+		It("returns a gcs driver when only json_key is provided", func() {
+			src.JSONKey = `{"type": "service_account"}`
+			aDriver, err := driver.FromSource(src)
+			Expect(err).To(BeNil())
+			Expect(aDriver).ToNot(BeNil())
+			gcsDriver, ok := aDriver.(*driver.GCSDriver)
+			Expect(ok).To(BeTrue())
+			Expect(gcsDriver.BucketName).To(Equal("my-bucket"))
+			Expect(gcsDriver.Key).To(Equal("my-key"))
+		})
+		It("returns a gcs driver when only token is provided", func() {
+			src.GCSToken = "ya29.some-token"
+			aDriver, err := driver.FromSource(src)
+			Expect(err).To(BeNil())
+			Expect(aDriver).ToNot(BeNil())
+			gcsDriver, ok := aDriver.(*driver.GCSDriver)
+			Expect(ok).To(BeTrue())
+			Expect(gcsDriver.BucketName).To(Equal("my-bucket"))
+			Expect(gcsDriver.Key).To(Equal("my-key"))
 		})
 	})
 })

--- a/driver/gcs.go
+++ b/driver/gcs.go
@@ -9,6 +9,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/blang/semver"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 
 	"github.com/concourse/semver-resource/version"
@@ -87,9 +88,17 @@ type IOServicer interface {
 
 type GCSIOServicer struct {
 	JSONCredentials string
+	Token           string
 }
 
-func (s *GCSIOServicer) GetObject(bucketName, objectName string) (io.ReadCloser, error) {
+func (s *GCSIOServicer) authOption() (option.ClientOption, error) {
+	if s.Token != "" {
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{
+			AccessToken: s.Token,
+		})
+		return option.WithTokenSource(tokenSource), nil
+	}
+
 	temp, err := os.CreateTemp("", "auth-credentials.json")
 	if err != nil {
 		return nil, err
@@ -99,12 +108,20 @@ func (s *GCSIOServicer) GetObject(bucketName, objectName string) (io.ReadCloser,
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(temp.Name())
+	// Close the file so the credentials can be read by the client
+	temp.Close()
+
+	return option.WithCredentialsFile(temp.Name()), nil
+}
+
+func (s *GCSIOServicer) GetObject(bucketName, objectName string) (io.ReadCloser, error) {
+	authOpt, err := s.authOption()
+	if err != nil {
+		return nil, err
+	}
+
 	ctx := context.Background()
-
-	authOption := option.WithCredentialsFile(temp.Name())
-	client, err := storage.NewClient(ctx, authOption)
-
+	client, err := storage.NewClient(ctx, authOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -116,21 +133,13 @@ func (s *GCSIOServicer) GetObject(bucketName, objectName string) (io.ReadCloser,
 }
 
 func (s *GCSIOServicer) PutObject(bucketName, objectName string) (io.WriteCloser, error) {
-	temp, err := os.CreateTemp("", "auth-credentials.json")
+	authOpt, err := s.authOption()
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = temp.WriteString(s.JSONCredentials)
-	if err != nil {
-		return nil, err
-	}
-	defer os.Remove(temp.Name())
 	ctx := context.Background()
-
-	authOption := option.WithCredentialsFile(temp.Name())
-	client, err := storage.NewClient(ctx, authOption)
-
+	client, err := storage.NewClient(ctx, authOpt)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/gcs.go
+++ b/driver/gcs.go
@@ -1,16 +1,14 @@
 package driver
 
 import (
+	"cloud.google.com/go/storage"
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"os"
-
-	"cloud.google.com/go/storage"
 	"github.com/blang/semver"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
+	"io"
 
 	"github.com/concourse/semver-resource/version"
 )
@@ -99,19 +97,7 @@ func (s *GCSIOServicer) authOption() (option.ClientOption, error) {
 		return option.WithTokenSource(tokenSource), nil
 	}
 
-	temp, err := os.CreateTemp("", "auth-credentials.json")
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = temp.WriteString(s.JSONCredentials)
-	if err != nil {
-		return nil, err
-	}
-	// Close the file so the credentials can be read by the client
-	temp.Close()
-
-	return option.WithCredentialsFile(temp.Name()), nil
+	return option.WithAuthCredentialsJSON(option.ServiceAccount, []byte(s.JSONCredentials)), nil
 }
 
 func (s *GCSIOServicer) GetObject(bucketName, objectName string) (io.ReadCloser, error) {

--- a/models/models.go
+++ b/models/models.go
@@ -83,7 +83,8 @@ type Source struct {
 
 	OpenStack OpenStackOptions `json:"openstack"`
 
-	JSONKey string `json:"json_key"`
+	JSONKey  string `json:"json_key"`
+	GCSToken string `json:"token"`
 }
 
 // OpenStackOptions contains properties for authenticating and accessing


### PR DESCRIPTION
Hey @taylorsilva, thanks for keeping Concourse alive! ❤️ 

Here is a small PR to allow semver to work with GCS tokens alongside json keys.