### PR TITLE
fix: trim spaces before parsing version file

### DIFF
--- a/driver/gcs.go
+++ b/driver/gcs.go
@@ -1,14 +1,16 @@
 package driver
 
 import (
-	"cloud.google.com/go/storage"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"strings"
+
+	"cloud.google.com/go/storage"
 	"github.com/blang/semver"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
-	"io"
 
 	"github.com/concourse/semver-resource/version"
 )
@@ -71,7 +73,7 @@ func (d *GCSDriver) Check(cursor *semver.Version) ([]semver.Version, error) {
 		return nil, err
 	}
 
-	v, err := semver.Parse(string(b))
+	v, err := semver.Parse(strings.TrimSpace(string(b)))
 	if err != nil {
 		return nil, fmt.Errorf("parsing number in bucket: %s", err)
 	}

--- a/driver/gcs_test.go
+++ b/driver/gcs_test.go
@@ -77,6 +77,21 @@ var _ = Describe("GCS Driver", func() {
 				Expect(s.Buf).To(gbytes.Say("0.0.1"))
 			})
 		})
+
+		Describe("when the object has a trailing newline", func() {
+			It("still bumps the version", func() {
+				s.Body = "2.3.4\n"
+
+				newV, err := driver.Bump(version.PatchBump{})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(newV.String()).To(Equal("2.3.5"))
+
+				Expect(s.BucketName).To(Equal("fake-bucket"))
+				Expect(s.ObjectName).To(Equal("fake-object"))
+				Expect(s.Buf).To(gbytes.Say("2.3.5"))
+			})
+		})
 	})
 
 	Describe("Set", func() {

--- a/driver/git.go
+++ b/driver/git.go
@@ -348,7 +348,7 @@ func (driver *GitDriver) readVersion() (semver.Version, bool, error) {
 		return semver.Version{}, false, err
 	}
 
-	currentVersion, err := semver.Parse(currentVersionStr)
+	currentVersion, err := semver.Parse(strings.TrimSpace(currentVersionStr))
 	if err != nil {
 		return semver.Version{}, false, err
 	}

--- a/driver/s3.go
+++ b/driver/s3.go
@@ -117,7 +117,9 @@ func (driver *S3Driver) Check(cursor *semver.Version) ([]semver.Version, error) 
 		}
 	}
 
-	bucketVersion, err := semver.Parse(bucketNumber)
+	// especially when manually fixing versions, extraneous newlines can
+	// be ended to the bucket file
+	bucketVersion, err := semver.Parse(strings.TrimSpace(bucketNumber))
 	if err != nil {
 		return nil, fmt.Errorf("parsing number in bucket: %s", err)
 	}


### PR DESCRIPTION
When manually updating a version file (either for creating an initial version manually or fixing a broken version), a lot of editors will ensure there is a trailing newline. This breaks version parsing for every driver except Swift. This PR simply ensures that every driver trims spaces on the version file content before parsing it.